### PR TITLE
v0.10.0 - Correctness & audit governance

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,15 +35,24 @@ jobs:
           set -o pipefail
           uv run pytest integration_tests/ -v | tee pytest-output.log
 
+      - name: Run catalogue audit
+        id: run_audit
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          uv run python scripts/audit_catalogue.py | tee audit-output.md
+
       - name: Upload test output
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pytest-output
-          path: pytest-output.log
+          path: |
+            pytest-output.log
+            audit-output.md
 
       - name: Open or update drift issue on failure
-        if: steps.run_tests.outcome == 'failure'
+        if: steps.run_tests.outcome == 'failure' || steps.run_audit.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -57,7 +66,8 @@ jobs:
           existing=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' || echo "")
 
           tail_log=$(tail -n 60 pytest-output.log || true)
-          body=$(printf "The nightly integration suite failed on %s.\n\nRun: %s\n\nLast lines of pytest output:\n\n\`\`\`\n%s\n\`\`\`\n" "$(date -u +%FT%TZ)" "$RUN_URL" "$tail_log")
+          audit_tail=$(tail -n 80 audit-output.md 2>/dev/null || echo "_audit output unavailable_")
+          body=$(printf "The nightly integration suite failed on %s.\n\nRun: %s\n\nLast lines of pytest output:\n\n\`\`\`\n%s\n\`\`\`\n\nCatalogue audit tail:\n\n%s\n" "$(date -u +%FT%TZ)" "$RUN_URL" "$tail_log" "$audit_tail")
 
           if [ -n "$existing" ]; then
             printf '%s\n' "$body" | gh issue comment "$existing" --body-file -
@@ -65,6 +75,6 @@ jobs:
             printf '%s\n' "$body" | gh issue create --title "$TITLE" --label "$LABEL" --body-file -
           fi
 
-      - name: Fail the job if tests failed
-        if: steps.run_tests.outcome == 'failure'
+      - name: Fail the job if tests or audit failed
+        if: steps.run_tests.outcome == 'failure' || steps.run_audit.outcome == 'failure'
         run: exit 1

--- a/integration_tests/test_abs_live.py
+++ b/integration_tests/test_abs_live.py
@@ -15,7 +15,7 @@ async def test_abs_cpi_structure_has_expected_shape() -> None:
     assert structure["id"] == "CPI"
     assert len(structure["dimensions"]) >= 5
     dim_ids = {dim["id"] for dim in structure["dimensions"]}
-    assert "TIME_PERIOD" in dim_ids
+    assert {"MEASURE", "REGION"} <= dim_ids
 
 
 async def test_abs_cpi_data_returns_observations() -> None:

--- a/scripts/audit_catalogue.py
+++ b/scripts/audit_catalogue.py
@@ -1,0 +1,215 @@
+"""Audit every catalogue entry against live upstream.
+
+Fetches the ABS dataflow registry and the RBA tables index, then diffs each
+entry's ``audit.upstream_title`` (and URL reachability) against live. Prints a
+markdown report to stdout in the same shape as
+``docs/coverage-audit-2026-04.md``. Exits non-zero if any drift is detected.
+
+Run via ``uv run python scripts/audit_catalogue.py`` or wire into CI.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import sys
+from collections.abc import Iterable
+from xml.etree import ElementTree as ET
+
+import httpx
+
+from ausecon_mcp.catalogue.abs import ABS_CATALOGUE
+from ausecon_mcp.catalogue.rba import RBA_CATALOGUE
+
+ABS_DATAFLOW_INDEX = "https://data.api.abs.gov.au/rest/dataflow/ABS"
+RBA_TABLES_INDEX = "https://www.rba.gov.au/statistics/tables/"
+
+_SDMX_NS = {
+    "message": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message",
+    "structure": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure",
+    "common": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common",
+}
+
+
+def fetch_abs_dataflows(client: httpx.Client) -> dict[str, str]:
+    """Return a mapping of ABS dataflow id -> current Name."""
+    resp = client.get(ABS_DATAFLOW_INDEX, timeout=60.0)
+    resp.raise_for_status()
+    root = ET.fromstring(resp.text)
+    out: dict[str, str] = {}
+    for df in root.findall(".//structure:Dataflow", _SDMX_NS):
+        df_id = df.attrib.get("id")
+        if not df_id:
+            continue
+        name_el = df.find("./common:Name", _SDMX_NS)
+        if name_el is not None and name_el.text:
+            out[df_id] = name_el.text.strip()
+    return out
+
+
+_RBA_ANCHOR = re.compile(
+    r"<a [^>]*href=\"(?:/statistics/tables/xls(?:-hist)?/|/statistics/historical-data\.html)"
+    r"[^\"]*\"[^>]*>(?P<text>[^<]+)</a>",
+    re.IGNORECASE,
+)
+_RBA_TITLE_ID = re.compile(
+    r"^(?P<title>.+?)\s*[\u2013\u2014-]\s*(?P<id>[A-Z][0-9]+(?:\.[0-9]+)?)\s*$",
+)
+
+
+def fetch_rba_tables(client: httpx.Client) -> dict[str, str]:
+    """Return a mapping of RBA table id (lower-cased) -> current title."""
+    resp = client.get(RBA_TABLES_INDEX, timeout=60.0)
+    resp.raise_for_status()
+    out: dict[str, str] = {}
+    for anchor in _RBA_ANCHOR.finditer(resp.text):
+        text = html.unescape(anchor.group("text")).strip()
+        m = _RBA_TITLE_ID.match(text)
+        if not m:
+            continue
+        table_id = m.group("id").lower()
+        title = re.sub(r"\s+", " ", m.group("title")).strip()
+        if table_id not in out or len(title) > len(out[table_id]):
+            out[table_id] = title
+    return out
+
+
+def _check_url(client: httpx.Client, url: str) -> bool:
+    try:
+        resp = client.head(url, timeout=30.0, follow_redirects=True)
+        if resp.status_code == 405:  # HEAD unsupported
+            resp = client.get(url, timeout=30.0, follow_redirects=True)
+        return resp.status_code < 400
+    except httpx.HTTPError:
+        return False
+
+
+_DASH_RE = re.compile(r"[\u2013\u2014\u2212]")
+
+
+def _normalise(title: str) -> str:
+    collapsed = re.sub(r"\s+", " ", title).strip().casefold()
+    return _DASH_RE.sub("-", collapsed)
+
+
+def audit(
+    catalogue: dict,
+    live: dict[str, str],
+    client: httpx.Client,
+    *,
+    source_label: str,
+    id_key: callable,
+) -> tuple[list[str], list[str], list[str]]:
+    """Return (drifted, disappeared, new) rows as markdown lines.
+
+    "Disappeared" means both: absent from live index, and the catalogued
+    upstream_url no longer 200s. An entry that has fallen off the index but
+    whose data file is still reachable is treated as active.
+    """
+    drifted: list[str] = []
+    disappeared: list[str] = []
+    catalogued_ids: set[str] = set()
+
+    for entry_id, entry in catalogue.items():
+        if entry.get("ceased") or entry.get("discontinued"):
+            continue
+        audit_meta = entry.get("audit") or {}
+        upstream_title = audit_meta.get("upstream_title", "")
+        upstream_url = audit_meta.get("upstream_url", "")
+        resolved_id = entry.get("upstream_id", entry_id)
+        live_id = id_key(resolved_id)
+        catalogued_ids.add(live_id)
+        live_title = live.get(live_id)
+        if live_title is None:
+            if upstream_url and _check_url(client, upstream_url):
+                continue  # Off the index but data file still live — treat as active.
+            disappeared.append(f"| `{entry_id}` | {upstream_title} | *not found in live index* |")
+            continue
+        if _normalise(live_title) != _normalise(upstream_title):
+            drifted.append(f"| `{entry_id}` | {upstream_title} | {live_title} |")
+
+    new_entries = sorted(set(live) - catalogued_ids)
+    new_rows = [f"| `{nid}` | {live[nid]} |" for nid in new_entries]
+    return drifted, disappeared, new_rows
+
+
+def _render(
+    source_label: str,
+    drifted: list[str],
+    disappeared: list[str],
+    new_rows: list[str],
+) -> Iterable[str]:
+    yield f"## {source_label}"
+    yield ""
+    yield "### Drifted (catalogue title differs from live)"
+    yield ""
+    if drifted:
+        yield "| Catalogue ID | Catalogued title | Live title |"
+        yield "|---|---|---|"
+        yield from drifted
+    else:
+        yield "_none_"
+    yield ""
+    yield "### Disappeared (not in live index)"
+    yield ""
+    if disappeared:
+        yield "| Catalogue ID | Catalogued title | Status |"
+        yield "|---|---|---|"
+        yield from disappeared
+    else:
+        yield "_none_"
+    yield ""
+    yield "### New (in live index, not catalogued)"
+    yield ""
+    if not new_rows:
+        yield "_none_"
+    elif len(new_rows) > 20:
+        yield f"_{len(new_rows)} uncatalogued live entries — informational only; "
+        yield "curate selectively via the roadmap. Showing first 10:_"
+        yield ""
+        yield "| Live ID | Live title |"
+        yield "|---|---|"
+        yield from new_rows[:10]
+    else:
+        yield "| Live ID | Live title |"
+        yield "|---|---|"
+        yield from new_rows
+    yield ""
+
+
+def main() -> int:
+    with httpx.Client(headers={"User-Agent": "ausecon-mcp-audit/1.0"}) as client:
+        abs_live = fetch_abs_dataflows(client)
+        rba_live = fetch_rba_tables(client)
+
+    with httpx.Client(
+        headers={"User-Agent": "ausecon-mcp-audit/1.0"}, follow_redirects=True
+    ) as client:
+        abs_drifted, abs_disappeared, abs_new = audit(
+            ABS_CATALOGUE,
+            abs_live,
+            client,
+            source_label="ABS",
+            id_key=lambda eid: eid,
+        )
+        rba_drifted, rba_disappeared, rba_new = audit(
+            RBA_CATALOGUE,
+            rba_live,
+            client,
+            source_label="RBA",
+            id_key=lambda eid: eid.lower(),
+        )
+
+    print("# Catalogue audit report")
+    print()
+    for line in _render("ABS", abs_drifted, abs_disappeared, abs_new):
+        print(line)
+    for line in _render("RBA", rba_drifted, rba_disappeared, rba_new):
+        print(line)
+
+    has_drift = bool(abs_drifted or abs_disappeared or rba_drifted or rba_disappeared)
+    return 1 if has_drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ausecon_mcp/catalogue/abs.py
+++ b/src/ausecon_mcp/catalogue/abs.py
@@ -31,6 +31,11 @@ ABS_CATALOGUE = {
             {"name": "trimmed_mean", "aliases": ["core", "trimmed mean"], "abs_key": None},
             {"name": "weighted_median", "aliases": ["weighted median"], "abs_key": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/latest",
+            "upstream_title": "Consumer Price Index (CPI)",
+        },
     },
     "CPI_M": {
         "id": "CPI_M",
@@ -56,7 +61,12 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
-        "discontinued": True,
+        "ceased": True,
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI_M/latest",
+            "upstream_title": "Monthly Consumer Price Index (CPI) indicator",
+        },
     },
     "PPI": {
         "id": "PPI",
@@ -82,6 +92,11 @@ ABS_CATALOGUE = {
             {"name": "export", "aliases": ["export prices"], "abs_key": None},
             {"name": "import", "aliases": ["import prices"], "abs_key": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/PPI/latest",
+            "upstream_title": "Producer Price Indexes by Industry",
+        },
     },
     "PPI_FD": {
         "id": "PPI_FD",
@@ -103,6 +118,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/PPI_FD/latest",
+            "upstream_title": "Producer Price Indexes, Final Demand",
+        },
     },
     "ITPI_EXP": {
         "id": "ITPI_EXP",
@@ -124,6 +144,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ITPI_EXP/latest",
+            "upstream_title": "Export Price Index",
+        },
     },
     "ITPI_IMP": {
         "id": "ITPI_IMP",
@@ -145,6 +170,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ITPI_IMP/latest",
+            "upstream_title": "Import Price Index",
+        },
     },
     "WPI": {
         "id": "WPI",
@@ -166,6 +196,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/WPI/latest",
+            "upstream_title": "Wage Price Index",
+        },
     },
     "AWE": {
         "id": "AWE",
@@ -187,9 +222,15 @@ ABS_CATALOGUE = {
         "frequencies": ["A"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/AWE/latest",
+            "upstream_title": "Average Weekly Earnings",
+        },
     },
-    "LCI": {
-        "id": "LCI",
+    "SLCI": {
+        "id": "SLCI",
+        "upstream_id": "LCI",
         "source": "abs",
         "name": "Selected Living Cost Indexes",
         "description": (
@@ -240,6 +281,11 @@ ABS_CATALOGUE = {
                 "abs_key": None,
             },
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LCI/latest",
+            "upstream_title": "Selected Living Cost Indexes",
+        },
     },
     "LF": {
         "id": "LF",
@@ -276,6 +322,11 @@ ABS_CATALOGUE = {
                 "abs_key": None,
             },
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LF/latest",
+            "upstream_title": "Labour Force",
+        },
     },
     "LF_HOURS": {
         "id": "LF_HOURS",
@@ -297,6 +348,11 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LF_HOURS/latest",
+            "upstream_title": "Labour Force: Hours worked by sector",
+        },
     },
     "LF_UNDER": {
         "id": "LF_UNDER",
@@ -318,6 +374,11 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LF_UNDER/latest",
+            "upstream_title": "Labour force - underemployment and underutilisation",
+        },
     },
     "LABOUR_ACCT_Q": {
         "id": "LABOUR_ACCT_Q",
@@ -341,6 +402,14 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LABOUR_ACCT_Q/latest",
+            "upstream_title": (
+                "Labour Account Australia, Final Quarterly Balanced: "
+                "Subdivision, Division and Total All Industries"
+            ),
+        },
     },
     "LABOUR_ACCT_A": {
         "id": "LABOUR_ACCT_A",
@@ -369,6 +438,14 @@ ABS_CATALOGUE = {
         "frequencies": ["A"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ABS_LABOUR_ACCT/latest",
+            "upstream_title": (
+                "Labour Account Australia, Annual Balanced: Subdivision, Division "
+                "and Total All Industries"
+            ),
+        },
     },
     "JV": {
         "id": "JV",
@@ -390,6 +467,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/JV/latest",
+            "upstream_title": "Job Vacancies",
+        },
     },
     "ANA_AGG": {
         "id": "ANA_AGG",
@@ -423,6 +505,11 @@ ABS_CATALOGUE = {
                 "abs_key": "M2.GPM.20.AUS.Q",
             }
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ANA_AGG/latest",
+            "upstream_title": "Australian National Accounts Key Aggregates",
+        },
     },
     "ANA_EXP": {
         "id": "ANA_EXP",
@@ -447,6 +534,13 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ANA_EXP/latest",
+            "upstream_title": (
+                "Australian National Accounts - Expenditure on Gross Domestic Product (GDP (E))"
+            ),
+        },
     },
     "ANA_INC": {
         "id": "ANA_INC",
@@ -471,6 +565,13 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ANA_INC/latest",
+            "upstream_title": (
+                "Australian National Accounts - Income from Gross Domestic Product (GDP (I))"
+            ),
+        },
     },
     "ANA_IND_GVA": {
         "id": "ANA_IND_GVA",
@@ -499,6 +600,13 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ANA_IND_GVA/latest",
+            "upstream_title": (
+                "Australian National Accounts - Production of Gross Domestic Product (GDP (P))"
+            ),
+        },
     },
     "ANA_SFD": {
         "id": "ANA_SFD",
@@ -536,6 +644,11 @@ ABS_CATALOGUE = {
             "act",
         ],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ANA_SFD/latest",
+            "upstream_title": "Australian National Accounts - State Final Demand",
+        },
     },
     "RT": {
         "id": "RT",
@@ -560,7 +673,12 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
-        "discontinued": True,
+        "ceased": True,
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/RT/latest",
+            "upstream_title": "Retail Trade",
+        },
     },
     "BUSINESS_TURNOVER": {
         "id": "BUSINESS_TURNOVER",
@@ -585,7 +703,12 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
-        "discontinued": True,
+        "ceased": True,
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/BUSINESS_TURNOVER/latest",
+            "upstream_title": "Monthly Business Turnover Indicator",
+        },
     },
     "QBIS": {
         "id": "QBIS",
@@ -615,6 +738,11 @@ ABS_CATALOGUE = {
             {"name": "sales", "aliases": [], "abs_key": None},
             {"name": "wages", "aliases": [], "abs_key": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/QBIS/latest",
+            "upstream_title": "Business Indicators",
+        },
     },
     "HSI_M": {
         "id": "HSI_M",
@@ -637,6 +765,11 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/HSI_M/latest",
+            "upstream_title": "Monthly Household Spending Indicator",
+        },
     },
     "CAPEX": {
         "id": "CAPEX",
@@ -660,6 +793,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/CAPEX/latest",
+            "upstream_title": "Private New Capital Expenditure and Expected Expenditure",
+        },
     },
     "BUILDING_ACTIVITY": {
         "id": "BUILDING_ACTIVITY",
@@ -684,6 +822,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/BUILDING_ACTIVITY/latest",
+            "upstream_title": "Building Activity",
+        },
     },
     "CWD": {
         "id": "CWD",
@@ -713,6 +856,11 @@ ABS_CATALOGUE = {
                 "abs_key": None,
             },
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/CWD/latest",
+            "upstream_title": "Construction Work Done, Preliminary",
+        },
     },
     "EWD": {
         "id": "EWD",
@@ -739,6 +887,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/EWD/latest",
+            "upstream_title": "Engineering Construction Work Done, Preliminary",
+        },
     },
     "RES_DWELL": {
         "id": "RES_DWELL",
@@ -760,6 +913,14 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/RES_DWELL/latest",
+            "upstream_title": (
+                "Residential Dwellings: Unstratified Medians and Transfer Counts "
+                "by Dwelling Type, GCCSA and Rest of State"
+            ),
+        },
     },
     "RPPI": {
         "id": "RPPI",
@@ -784,7 +945,12 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
-        "discontinued": True,
+        "ceased": True,
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/RPPI/latest",
+            "upstream_title": "Residential Property Price Index",
+        },
     },
     "ITGS": {
         "id": "ITGS",
@@ -810,6 +976,11 @@ ABS_CATALOGUE = {
             {"name": "imports", "aliases": [], "abs_key": None},
             {"name": "trade_balance", "aliases": ["net exports"], "abs_key": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ITGS/latest",
+            "upstream_title": "International Trade in Goods",
+        },
     },
     "MERCH_EXP": {
         "id": "MERCH_EXP",
@@ -831,6 +1002,11 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/MERCH_EXP/latest",
+            "upstream_title": "Merchandise Exports by Commodity (SITC), Country and State",
+        },
     },
     "MERCH_IMP": {
         "id": "MERCH_IMP",
@@ -852,6 +1028,11 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/MERCH_IMP/latest",
+            "upstream_title": "Merchandise Imports by Commodity (SITC), Country and State",
+        },
     },
     "BOP": {
         "id": "BOP",
@@ -877,6 +1058,11 @@ ABS_CATALOGUE = {
             {"name": "capital_account", "aliases": [], "abs_key": None},
             {"name": "financial_account", "aliases": [], "abs_key": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/BOP/latest",
+            "upstream_title": "Balance of Payments",
+        },
     },
     "BOP_GOODS": {
         "id": "BOP_GOODS",
@@ -898,6 +1084,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/BOP_GOODS/latest",
+            "upstream_title": "Balance of Payments: Goods Exports and Imports",
+        },
     },
     "BOP_STATE": {
         "id": "BOP_STATE",
@@ -931,6 +1122,11 @@ ABS_CATALOGUE = {
             "act",
         ],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/BOP_STATE/latest",
+            "upstream_title": "Balance of Payments by State",
+        },
     },
     "IIP": {
         "id": "IIP",
@@ -952,6 +1148,11 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/IIP/latest",
+            "upstream_title": "International Investment Position",
+        },
     },
     "LEND_HOUSING": {
         "id": "LEND_HOUSING",
@@ -976,6 +1177,11 @@ ABS_CATALOGUE = {
             {"name": "owner_occupier", "aliases": ["owner-occupier"], "abs_key": None},
             {"name": "investor", "aliases": ["investment"], "abs_key": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LEND_HOUSING/latest",
+            "upstream_title": "Lending Indicators Housing Finance",
+        },
     },
     "LEND_BUSINESS": {
         "id": "LEND_BUSINESS",
@@ -997,6 +1203,11 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LEND_BUSINESS/latest",
+            "upstream_title": "Lending Indicators Business Finance",
+        },
     },
     "LEND_PERSONAL": {
         "id": "LEND_PERSONAL",
@@ -1018,6 +1229,11 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LEND_PERSONAL/latest",
+            "upstream_title": "Lending Indicators Personal Finance",
+        },
     },
     "ERP_Q": {
         "id": "ERP_Q",
@@ -1041,6 +1257,13 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ERP_Q/latest",
+            "upstream_title": (
+                "Quarterly Population Estimates (ERP), by State/Territory, Sex and Age"
+            ),
+        },
     },
     "ERP_COMP_Q": {
         "id": "ERP_COMP_Q",
@@ -1070,6 +1293,13 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ERP_COMP_Q/latest",
+            "upstream_title": (
+                "Population and components of change - national, states and territories"
+            ),
+        },
     },
     "POP_PROJ": {
         "id": "POP_PROJ",
@@ -1095,6 +1325,11 @@ ABS_CATALOGUE = {
         "frequencies": ["A"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/POP_PROJ/latest",
+            "upstream_title": "Population Projections, Australia, 2022-2071",
+        },
     },
     "NOM_FY": {
         "id": "NOM_FY",
@@ -1116,6 +1351,14 @@ ABS_CATALOGUE = {
         "frequencies": ["A"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/NOM_FY/latest",
+            "upstream_title": (
+                "Net overseas migration: Arrivals, departures and net, State/territory, "
+                "Age and sex - Financial years, 2004-05 onwards"
+            ),
+        },
     },
     "OAD_COUNTRY": {
         "id": "OAD_COUNTRY",
@@ -1137,5 +1380,13 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/OAD_COUNTRY/latest",
+            "upstream_title": (
+                "Visitor arrivals and resident "
+                "returns, Selected Countries of Residence/Destinations"
+            ),
+        },
     },
 }

--- a/src/ausecon_mcp/catalogue/rba.py
+++ b/src/ausecon_mcp/catalogue/rba.py
@@ -19,6 +19,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/a1-data.csv",
+            "upstream_title": "RBA Balance Sheet",
+        },
     },
     "a2": {
         "id": "a2",
@@ -47,6 +52,11 @@ RBA_CATALOGUE = {
                 "rba_series_ids": ["ARBAMPCNCRT"],
             }
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/a2-data.csv",
+            "upstream_title": "Changes in Monetary Policy and Administered Rates",
+        },
     },
     "a3": {
         "id": "a3",
@@ -73,14 +83,20 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/a3-data.csv",
+            "upstream_title": "Monetary Policy Operations – Current",
+        },
     },
     "a5": {
         "id": "a5",
         "source": "rba",
         "name": "Daily Foreign Exchange Market Intervention Transactions",
         "description": (
-            "Discontinued daily record of Reserve Bank foreign exchange market "
-            "intervention transactions."
+            "Daily record of Reserve Bank foreign exchange market intervention "
+            "transactions (A$m). Updates are event-driven and infrequent — "
+            "most observations are zero."
         ),
         "frequency": "Daily",
         "category": "exchange_rates",
@@ -90,14 +106,17 @@ RBA_CATALOGUE = {
             "rba fx intervention",
         ],
         "tags": [
-            "discontinued",
             "fx intervention",
             "rba operations",
         ],
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
-        "discontinued": True,
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/a5-data.csv",
+            "upstream_title": "Daily Foreign Exchange Market Intervention Transactions",
+        },
     },
     "b1": {
         "id": "b1",
@@ -124,6 +143,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/b1-data.csv",
+            "upstream_title": "Assets of Financial Institutions",
+        },
     },
     "b2": {
         "id": "b2",
@@ -149,6 +173,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/b2-data.csv",
+            "upstream_title": "Banks – Off-balance Sheet Business",
+        },
     },
     "b3": {
         "id": "b3",
@@ -175,6 +204,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/b3-data.csv",
+            "upstream_title": "Repurchase Agreements and Stock Lending by Banks and RFCs",
+        },
     },
     "c1": {
         "id": "c1",
@@ -196,6 +230,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c1-data.csv",
+            "upstream_title": "Credit and Charge Cards – Seasonally Adjusted Series",
+        },
     },
     "c1.2": {
         "id": "c1.2",
@@ -222,6 +261,13 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c1.2-data.csv",
+            "upstream_title": (
+                "Credit and Charge Cards – Original Series – Personal and Commercial Cards"
+            ),
+        },
     },
     "c2": {
         "id": "c2",
@@ -246,6 +292,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c2-data.csv",
+            "upstream_title": "Debit Cards – Seasonally Adjusted Series",
+        },
     },
     "c3": {
         "id": "c3",
@@ -270,6 +321,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c3-data.csv",
+            "upstream_title": "Average Merchant Fees for Debit, Credit and Charge Cards",
+        },
     },
     "c4": {
         "id": "c4",
@@ -294,6 +350,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c4-data.csv",
+            "upstream_title": "ATMs – Seasonally Adjusted Series",
+        },
     },
     "c5": {
         "id": "c5",
@@ -318,6 +379,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c5-data.csv",
+            "upstream_title": "Cheques – Seasonally Adjusted Series",
+        },
     },
     "c6": {
         "id": "c6",
@@ -346,6 +412,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c6-data.csv",
+            "upstream_title": "Direct Entry and NPP – Seasonally Adjusted Series",
+        },
     },
     "c7": {
         "id": "c7",
@@ -372,6 +443,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c7-data.csv",
+            "upstream_title": "Real-time Gross Settlement Statistics",
+        },
     },
     "c8": {
         "id": "c8",
@@ -398,6 +474,11 @@ RBA_CATALOGUE = {
         "frequencies": ["A"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c8-data.csv",
+            "upstream_title": "Points of Access to the Australian Payments System",
+        },
     },
     "c9": {
         "id": "c9",
@@ -424,6 +505,11 @@ RBA_CATALOGUE = {
         "frequencies": ["A"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/c9-data.csv",
+            "upstream_title": "Domestic Banking Fees Charged",
+        },
     },
     "d1": {
         "id": "d1",
@@ -448,6 +534,11 @@ RBA_CATALOGUE = {
             {"name": "credit", "aliases": ["credit growth"], "rba_series_ids": None},
             {"name": "money", "aliases": ["money growth", "broad money"], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d1-data.csv",
+            "upstream_title": "Growth in Selected Financial Aggregates",
+        },
     },
     "d2": {
         "id": "d2",
@@ -473,6 +564,11 @@ RBA_CATALOGUE = {
             {"name": "business", "aliases": ["business credit"], "rba_series_ids": None},
             {"name": "household", "aliases": ["household credit"], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d2-data.csv",
+            "upstream_title": "Lending and Credit Aggregates",
+        },
     },
     "d3": {
         "id": "d3",
@@ -498,6 +594,11 @@ RBA_CATALOGUE = {
             {"name": "deposits", "aliases": [], "rba_series_ids": None},
             {"name": "broad_money", "aliases": ["m3"], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d3-data.csv",
+            "upstream_title": "Monetary Aggregates",
+        },
     },
     "d4": {
         "id": "d4",
@@ -524,6 +625,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d4-data.csv",
+            "upstream_title": "Debt Securities Outstanding",
+        },
     },
     "d5": {
         "id": "d5",
@@ -548,6 +654,11 @@ RBA_CATALOGUE = {
             {"name": "business", "aliases": ["business lending"], "rba_series_ids": None},
             {"name": "household", "aliases": ["household lending"], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d5-data.csv",
+            "upstream_title": "Bank Lending Classified by Sector",
+        },
     },
     "d9": {
         "id": "d9",
@@ -573,6 +684,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d9-data.csv",
+            "upstream_title": "Rural Debt by Lender",
+        },
     },
     "d10": {
         "id": "d10",
@@ -597,6 +713,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d10-data.csv",
+            "upstream_title": "Margin Lending",
+        },
     },
     "d14": {
         "id": "d14",
@@ -627,6 +748,14 @@ RBA_CATALOGUE = {
             {"name": "medium_business", "aliases": [], "rba_series_ids": None},
             {"name": "large_business", "aliases": [], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/d14-data.csv",
+            "upstream_title": (
+                "Lending to Business – Business Finance Outstanding "
+                "by Business Size and Interest Rate Type"
+            ),
+        },
     },
     "e1": {
         "id": "e1",
@@ -651,6 +780,11 @@ RBA_CATALOGUE = {
             {"name": "household", "aliases": ["household debt"], "rba_series_ids": None},
             {"name": "business", "aliases": [], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/e1-data.csv",
+            "upstream_title": "Household and Business Balance Sheets",
+        },
     },
     "e2": {
         "id": "e2",
@@ -674,6 +808,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/e2-data.csv",
+            "upstream_title": "Household Finances – Selected Ratios",
+        },
     },
     "e13": {
         "id": "e13",
@@ -700,6 +839,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/e13-data.csv",
+            "upstream_title": "Housing Loan Payments",
+        },
     },
     "f1": {
         "id": "f1",
@@ -728,6 +872,11 @@ RBA_CATALOGUE = {
                 "rba_series_ids": None,
             },
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f1-data.csv",
+            "upstream_title": "Interest Rates and Yields – Money Market – Daily",
+        },
     },
     "f2": {
         "id": "f2",
@@ -749,6 +898,11 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f2-data.csv",
+            "upstream_title": "Capital Market Yields – Government Bonds – Daily",
+        },
     },
     "f3": {
         "id": "f3",
@@ -771,6 +925,11 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f3-data.csv",
+            "upstream_title": "Aggregate Measures of Australian Corporate Bond Yields",
+        },
     },
     "f4": {
         "id": "f4",
@@ -797,6 +956,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f4-data.csv",
+            "upstream_title": "Advertised Deposit Rates",
+        },
     },
     "f4.1": {
         "id": "f4.1",
@@ -822,6 +986,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f4.1-data.csv",
+            "upstream_title": "Paid Deposit Rates",
+        },
     },
     "f5": {
         "id": "f5",
@@ -847,6 +1016,11 @@ RBA_CATALOGUE = {
             {"name": "housing", "aliases": ["housing loan rates"], "rba_series_ids": None},
             {"name": "personal", "aliases": ["personal loan rates"], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f5-data.csv",
+            "upstream_title": "Indicator Lending Rates",
+        },
     },
     "f6": {
         "id": "f6",
@@ -871,6 +1045,11 @@ RBA_CATALOGUE = {
             {"name": "owner_occupier", "aliases": ["owner-occupier"], "rba_series_ids": None},
             {"name": "investor", "aliases": ["investment"], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f6-data.csv",
+            "upstream_title": "Housing Lending Rates",
+        },
     },
     "f7": {
         "id": "f7",
@@ -895,6 +1074,11 @@ RBA_CATALOGUE = {
             {"name": "small_business", "aliases": ["sme rates"], "rba_series_ids": None},
             {"name": "large_business", "aliases": [], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f7-data.csv",
+            "upstream_title": "Business Lending Rates",
+        },
     },
     "f8": {
         "id": "f8",
@@ -921,6 +1105,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f8-data.csv",
+            "upstream_title": "Personal Lending Rates",
+        },
     },
     "f11": {
         "id": "f11",
@@ -945,6 +1134,11 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f11-data.csv",
+            "upstream_title": "Exchange Rates - Historical - Daily and Monthly",
+        },
     },
     "f11.1": {
         "id": "f11.1",
@@ -971,6 +1165,11 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f11.1-data.csv",
+            "upstream_title": "Exchange Rates - Daily - 2023 to Current",
+        },
     },
     "f12": {
         "id": "f12",
@@ -994,6 +1193,11 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f12-data.csv",
+            "upstream_title": "US Dollar Exchange Rates",
+        },
     },
     "f15": {
         "id": "f15",
@@ -1015,6 +1219,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f15-data.csv",
+            "upstream_title": "Real Exchange Rate Measures",
+        },
     },
     "f16": {
         "id": "f16",
@@ -1043,6 +1252,11 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f16-data.csv",
+            "upstream_title": "Indicative Mid Rates of Selected Australian Government Securities",
+        },
     },
     "f17": {
         "id": "f17",
@@ -1072,6 +1286,11 @@ RBA_CATALOGUE = {
         "frequencies": ["D"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f17-yields.csv",
+            "upstream_title": "Zero-coupon Interest Rates – Analytical Series – 2017 to Current",
+        },
     },
     "g1": {
         "id": "g1",
@@ -1111,6 +1330,11 @@ RBA_CATALOGUE = {
                 "rba_series_ids": None,
             },
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/g1-data.csv",
+            "upstream_title": "Consumer Price Inflation",
+        },
     },
     "g2": {
         "id": "g2",
@@ -1132,6 +1356,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/g2-data.csv",
+            "upstream_title": "Consumer Price Inflation – Expenditure Groups",
+        },
     },
     "g3": {
         "id": "g3",
@@ -1157,6 +1386,11 @@ RBA_CATALOGUE = {
             {"name": "market", "aliases": ["market expectations"], "rba_series_ids": None},
             {"name": "union", "aliases": [], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/g3-data.csv",
+            "upstream_title": "Inflation Expectations",
+        },
     },
     "g4": {
         "id": "g4",
@@ -1183,6 +1417,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/g4-data.csv",
+            "upstream_title": "Consumer Price Inflation – Monthly Collection",
+        },
     },
     "h1": {
         "id": "h1",
@@ -1208,6 +1447,11 @@ RBA_CATALOGUE = {
             {"name": "gdp", "aliases": ["output", "economic growth"], "rba_series_ids": None},
             {"name": "income", "aliases": [], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/h1-data.csv",
+            "upstream_title": "Gross Domestic Product and Income",
+        },
     },
     "h2": {
         "id": "h2",
@@ -1235,6 +1479,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/h2-data.csv",
+            "upstream_title": "Demand and Income",
+        },
     },
     "h3": {
         "id": "h3",
@@ -1256,6 +1505,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/h3-data.csv",
+            "upstream_title": "Monthly Activity Indicators",
+        },
     },
     "h4": {
         "id": "h4",
@@ -1282,6 +1536,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/h4-data.csv",
+            "upstream_title": "Labour Costs and Productivity",
+        },
     },
     "h5": {
         "id": "h5",
@@ -1318,6 +1577,11 @@ RBA_CATALOGUE = {
                 "rba_series_ids": None,
             },
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/h5-data.csv",
+            "upstream_title": "Labour Force",
+        },
     },
     "i1": {
         "id": "i1",
@@ -1342,6 +1606,11 @@ RBA_CATALOGUE = {
             {"name": "trade", "aliases": ["international trade"], "rba_series_ids": None},
             {"name": "current_account", "aliases": [], "rba_series_ids": None},
         ],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/i1-data.csv",
+            "upstream_title": "International Trade and Balance of Payments",
+        },
     },
     "i2": {
         "id": "i2",
@@ -1369,6 +1638,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/i2-data.csv",
+            "upstream_title": "Commodity Prices",
+        },
     },
     "i3": {
         "id": "i3",
@@ -1395,6 +1669,11 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/i3-data.csv",
+            "upstream_title": "Balance of Payments – Financial Account",
+        },
     },
     "i4": {
         "id": "i4",
@@ -1422,5 +1701,10 @@ RBA_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [],
+        "audit": {
+            "last_audited": "2026-04-18",
+            "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/i4-data.csv",
+            "upstream_title": "Australia's Gross Foreign Assets and Liabilities",
+        },
     },
 }

--- a/src/ausecon_mcp/catalogue/search.py
+++ b/src/ausecon_mcp/catalogue/search.py
@@ -32,7 +32,7 @@ def search_catalogue(query: str, source: str | None = None) -> list[dict]:
 
     for collection_source, collection in _iter_collections(source):
         for entry in collection.values():
-            if entry.get("discontinued", False):
+            if entry.get("discontinued", False) or entry.get("ceased", False):
                 continue
 
             score = _score_entry(query_text, query_terms, entry)

--- a/src/ausecon_mcp/prompts.py
+++ b/src/ausecon_mcp/prompts.py
@@ -88,7 +88,7 @@ def register_prompts(mcp: FastMCP) -> None:
     @mcp.prompt(
         name="living_costs_vs_cpi",
         description=(
-            "Compare Selected Living Cost Indexes (LCI) across household types "
+            "Compare Selected Living Cost Indexes (SLCI) across household types "
             "against headline CPI to show cost-of-living divergence."
         ),
     )
@@ -97,17 +97,17 @@ def register_prompts(mcp: FastMCP) -> None:
         return (
             "The user wants to see how cost-of-living pressures differ across "
             "Australian household types compared with the headline CPI. "
-            "LCI weights reflect actual spending patterns for each household "
+            "SLCI weights reflect actual spending patterns for each household "
             "type, so the series can diverge materially from CPI.\n"
             "\n"
             "Do the following using tools from this MCP server:\n"
-            f"1. Call `get_abs_data` with dataflow_id=\"LCI\" and {start_clause} "
+            f'1. Call `get_abs_data` with dataflow_id="SLCI" and {start_clause} '
             "to retrieve Selected Living Cost Indexes across household types.\n"
             f'2. Call `get_economic_series` with concept="headline_cpi" '
             f"using {start_clause} for the CPI benchmark.\n"
             "\n"
             "Then write 4-6 sentences covering:\n"
-            "- the LCI household type with the highest annual change and its value,\n"
+            "- the SLCI household type with the highest annual change and its value,\n"
             "- the household type with the lowest, and the gap between them,\n"
             "- how both compare to headline CPI over the same window,\n"
             "- a plain-language interpretation (which households are feeling "

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -35,7 +35,6 @@ def test_rba_catalogue_covers_active_tables_and_tracks_discontinued_state() -> N
     ]
 
     assert len(active_tables) >= 30
-    assert any(entry.get("discontinued", False) for entry in RBA_CATALOGUE.values())
     assert {
         "monetary_policy",
         "payments",
@@ -80,22 +79,16 @@ def test_search_catalogue_prefers_full_economist_query_matches() -> None:
     assert results[0]["id"] == "LF"
 
 
-def test_search_catalogue_excludes_discontinued_rba_tables() -> None:
-    results = search_catalogue("rba fx intervention", source="rba")
-
-    assert results == []
-
-
-def test_search_catalogue_excludes_discontinued_abs_dataflows() -> None:
+def test_search_catalogue_excludes_ceased_abs_dataflows() -> None:
     for ceased_id in ("BUSINESS_TURNOVER", "CPI_M", "RT", "RPPI"):
         results = search_catalogue(ceased_id, source="abs")
         assert all(item["id"] != ceased_id for item in results), (
-            f"{ceased_id} is marked discontinued but still appeared in search results"
+            f"{ceased_id} is marked ceased but still appeared in search results"
         )
 
 
-def test_lci_resolves_to_selected_living_cost_indexes() -> None:
-    entry = ABS_CATALOGUE["LCI"]
+def test_slci_resolves_to_selected_living_cost_indexes() -> None:
+    entry = ABS_CATALOGUE["SLCI"]
 
     assert entry["name"] == "Selected Living Cost Indexes"
     assert "selected living cost indexes" in entry["aliases"]

--- a/tests/test_catalogue_audit.py
+++ b/tests/test_catalogue_audit.py
@@ -1,0 +1,44 @@
+"""Every catalogue entry must carry a fresh `audit` block.
+
+Guards against silent upstream drift: entries without a recent re-verification
+should be treated as stale and investigated. Bootstrap tolerance is 24 months;
+tighten once governance is routine.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from ausecon_mcp.catalogue.abs import ABS_CATALOGUE
+from ausecon_mcp.catalogue.rba import RBA_CATALOGUE
+
+MAX_AGE_MONTHS = 24
+
+
+def _iter_entries():
+    for entry_id, entry in ABS_CATALOGUE.items():
+        yield f"abs/{entry_id}", entry
+    for entry_id, entry in RBA_CATALOGUE.items():
+        yield f"rba/{entry_id}", entry
+
+
+@pytest.mark.parametrize(("label", "entry"), list(_iter_entries()))
+def test_entry_has_audit_block(label: str, entry: dict) -> None:
+    audit = entry.get("audit")
+    assert audit is not None, f"{label}: missing audit block"
+    for key in ("last_audited", "upstream_url", "upstream_title"):
+        assert audit.get(key), f"{label}: audit.{key} missing or empty"
+
+
+@pytest.mark.parametrize(("label", "entry"), list(_iter_entries()))
+def test_audit_last_audited_recent(label: str, entry: dict) -> None:
+    audit = entry["audit"]
+    last_audited = date.fromisoformat(audit["last_audited"])
+    today = date.today()
+    months_old = (today.year - last_audited.year) * 12 + (today.month - last_audited.month)
+    assert months_old <= MAX_AGE_MONTHS, (
+        f"{label}: last_audited {last_audited} is {months_old} months old "
+        f"(max {MAX_AGE_MONTHS}); re-run scripts/audit_catalogue.py"
+    )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -72,7 +72,7 @@ async def test_living_costs_vs_cpi_references_lci_and_cpi() -> None:
     async with Client(mcp) as client:
         text = await _get_prompt_text(client, "living_costs_vs_cpi", {"start": "2021-Q1"})
 
-    assert "LCI" in text
+    assert "SLCI" in text
     assert "headline_cpi" in text
     assert "2021-Q1" in text
 

--- a/tests/test_rba_provider.py
+++ b/tests/test_rba_provider.py
@@ -17,7 +17,6 @@ def test_rba_provider_lists_tables_by_category() -> None:
     ids = [item["id"] for item in results]
 
     assert "f11" in ids
-    assert "a5" not in ids
     assert all(item["discontinued"] is False for item in results)
 
 
@@ -29,8 +28,6 @@ def test_rba_provider_can_include_discontinued_tables() -> None:
     ids = [item["id"] for item in results]
 
     assert "f11" in ids
-    assert "a5" in ids
-    assert any(item["id"] == "a5" and item["discontinued"] is True for item in results)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Catalogue corrections: `LCI` → `SLCI` rename (upstream_id preserved), 4 ABS entries switched from `discontinued` to `ceased`, `a5` un-discontinued after live verification
- Audit governance: `audit` block on every catalogue entry (~100), new `scripts/audit_catalogue.py` diffs catalogue vs live ABS/RBA indexes, freshness test enforces 24-month ceiling
- CI: nightly Integration workflow now runs the audit step and surfaces drift via the existing `upstream-drift` issue

## Test plan
- [x] `uv run ruff check src tests scripts` — clean
- [x] `uv run pytest` — 342 passed
- [ ] Trigger Integration workflow via `workflow_dispatch` and confirm audit step completes
- [ ] Spot-check `audit-output.md` artifact for no unexpected drift