### PR TITLE
v0.11.0: semantic layer expansion + discovery ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Releases are published to [PyPI](https://pypi.org/project/ausecon-mcp-server/) a
 
 Current capabilities:
 
-- six read-only MCP tools covering dataset discovery, ABS structure inspection, ABS and RBA data retrieval, and a small semantic shortcut layer for common macroeconomic concepts
-- three read-only MCP resources exposing the curated catalogue and per-entry metadata without making live upstream calls
-- six MCP prompt templates for common economist workflows such as inflation summaries, macro snapshots, living-cost comparisons, construction pipeline reviews, and dataset discovery
+- seven read-only MCP tools covering dataset discovery (including an unranked `list_catalogue` complement to `search_datasets`), ABS structure inspection, ABS and RBA data retrieval, and a semantic shortcut layer with 28 curated macroeconomic concepts
+- four read-only MCP resources exposing the curated catalogue, per-entry metadata, and an `ausecon://concepts` index of every semantic shortcut with its resolved target
+- eight MCP prompt templates for common economist workflows such as inflation summaries, macro snapshots, living-cost comparisons, construction pipeline reviews, labour slack, yield curve snapshots, and dataset discovery
 - provenance-rich JSON responses, structured JSON logging to stderr, and dual-layer caching that survives client restarts
 
 At this stage, the server should still be treated as an opinionated early release rather than a
@@ -35,27 +35,98 @@ The MCP server currently exposes the following tools:
 | Tool | Purpose | Key inputs |
 | --- | --- | --- |
 | `search_datasets` | Search the curated ABS and RBA catalogue with deterministic ranking | `query`, `source` |
+| `list_catalogue` | List catalogue entries unranked, optionally filtered by source, category, or tag | `source`, `category`, `tag`, `include_ceased`, `include_discontinued` |
 | `get_abs_dataset_structure` | Retrieve ABS SDMX dimensions and code lists | `dataflow_id` |
 | `get_abs_data` | Retrieve ABS data in a normalised response shape | `dataflow_id`, `key`, `start_period`, `end_period`, `last_n`, `updated_after` |
 | `list_rba_tables` | List curated RBA statistical tables | `category`, `include_discontinued` |
 | `get_rba_table` | Retrieve an RBA statistical table in a normalised response shape | `table_id`, `series_ids`, `start_date`, `end_date`, `last_n` |
-| `get_economic_series` | Resolve a small set of high-value economic concepts to ABS or RBA retrievals | `concept`, `variant`, `geography`, `frequency`, `start`, `end` |
+| `get_economic_series` | Resolve a curated economic concept to an ABS or RBA retrieval | `concept`, `variant`, `geography`, `frequency`, `start`, `end`, `last_n` |
 
 ### Currently supported semantic concepts
 
-`get_economic_series` currently supports:
+`get_economic_series` resolves 28 curated concepts across prices, labour, activity, monetary
+policy, financial markets, external sector, and credit. The full list is also available at runtime
+via the `ausecon://concepts` resource.
 
-- `cash_rate_target`
-- `headline_cpi`
-- `trimmed_mean_inflation`
-- `gdp_growth`
+**Prices and inflation**
 
-By default, these currently resolve to the following narrowed series:
+| Concept | Source | Default mapping |
+| --- | --- | --- |
+| `headline_cpi` | ABS `CPI` | All groups CPI, Australia, quarterly (`1.10001.10.50.Q`) |
+| `trimmed_mean_inflation` | RBA `g1` | Year-ended trimmed mean inflation (`GCPIOCPMTMYP`) |
+| `weighted_median_inflation` | RBA `g1` | Year-ended weighted median inflation (`GCPIOCPMWMYP`) |
+| `monthly_inflation` | RBA `g4` | Monthly headline CPI year-ended (`GCPIAGSAMP`) |
+| `producer_price_inflation` | ABS `PPI_FD` | Final demand PPI, Australia, quarterly |
+| `living_cost_index` | ABS `SLCI` | Selected Living Cost Indexes |
 
-- `cash_rate_target` -> RBA `a2` cash rate target series (`ARBAMPCNCRT`)
-- `headline_cpi` -> ABS `CPI` all groups CPI index for Australia, quarterly (`1.10001.10.50.Q`)
-- `trimmed_mean_inflation` -> RBA `g1` year-ended trimmed mean inflation (`GCPIOCPMTMYP`)
-- `gdp_growth` -> ABS `ANA_AGG` quarterly real GDP growth (`M2.GPM.20.AUS.Q`)
+**Labour**
+
+| Concept | Source | Default mapping |
+| --- | --- | --- |
+| `unemployment_rate` | ABS `LF` | Unemployment rate, Australia, seasonally adjusted, monthly |
+| `underemployment_rate` | ABS `LF_UNDER` | Underemployment rate, Australia, seasonally adjusted, monthly (composed via structure `DS_LF_UNDER`) |
+| `employment_total` | ABS `LF` | Employed total, Australia, seasonally adjusted, monthly |
+| `participation_rate` | ABS `LF` | Participation rate, Australia, seasonally adjusted, monthly |
+| `hours_worked` | ABS `LF_HOURS` | Monthly hours worked in all jobs, Australia, seasonally adjusted |
+| `job_vacancies` | ABS `JV` | Total job vacancies, Australia, seasonally adjusted, quarterly |
+| `wage_growth` | ABS `WPI` | Wage Price Index, Australia, all sectors, quarterly |
+
+**Activity**
+
+| Concept | Source | Default mapping |
+| --- | --- | --- |
+| `gdp_growth` | ABS `ANA_AGG` | Quarterly real GDP growth (`M2.GPM.20.AUS.Q`) |
+| `household_spending` | ABS `HSI_M` | Household Spending Indicator, Australia, seasonally adjusted, current prices |
+| `population` | ABS `ERP_Q` | Estimated resident population, Australia, quarterly |
+
+**Monetary policy and rates**
+
+| Concept | Source | Default mapping |
+| --- | --- | --- |
+| `cash_rate_target` | RBA `a2` | Cash rate target (`ARBAMPCNCRT`) |
+| `government_bond_yield_3y` | RBA `f17` | 3-year zero-coupon AGS yield (`FZCY0300D`) |
+| `government_bond_yield_10y` | RBA `f17` | 10-year zero-coupon AGS yield (`FZCY1000D`) |
+| `mortgage_rate` | RBA `f6` | Owner-occupier variable housing rate (`FLRHOOVA`) |
+| `small_business_rate` | RBA `f7` | Small business lending rate indicator |
+
+**FX**
+
+| Concept | Source | Default mapping |
+| --- | --- | --- |
+| `aud_usd` | RBA `f11` | AUD/USD spot (`FXRUSD`) |
+| `trade_weighted_index` | RBA `f11` | Trade-weighted index (`FXRTWI`) |
+
+**External sector**
+
+| Concept | Source | Default mapping |
+| --- | --- | --- |
+| `exports_goods_services` | ABS `ITGS` | Total exports of goods and services |
+| `imports_goods_services` | ABS `ITGS` | Total imports of goods and services |
+| `current_account_balance` | ABS `BOP` | Current account balance, Australia, seasonally adjusted, quarterly |
+| `commodity_prices` | RBA `i2` | RBA Index of Commodity Prices (SDR terms, `GRCPAISDR`) |
+
+**Credit**
+
+| Concept | Source | Default mapping |
+| --- | --- | --- |
+| `housing_credit` | RBA `d2` | Owner-occupier + investor housing credit, seasonally adjusted (`DLCACOHS`, `DLCACIHS`) |
+| `business_credit` | RBA `d2` | Business credit, seasonally adjusted (`DLCACBS`) |
+| `consumer_credit` | RBA `g3` | Consumer credit outstanding |
+
+**Locked default choices**
+
+A few defaults deserve calling out explicitly:
+
+- **`government_bond_yield_*` resolve to `f17`** (zero-coupon AGS yields), not `f16` (indicative
+  yields). `f17` is maintained for modelling and avoids the coupon-driven quirks of `f16`.
+- **`housing_credit` returns two series from `d2`** (`DLCACOHS` owner-occupier + `DLCACIHS`
+  investor) rather than a pre-aggregated total. Clients can sum them; we do not derive an
+  aggregate series.
+- **`producer_price_inflation` uses `PPI_FD`** (final demand), not the input-stage `PPI`, because
+  final demand is the headline measure most analysts track.
+- **`underemployment_rate` uses `LF_UNDER`** (dataflow id) but composes its SDMX key against
+  structure id `DS_LF_UNDER`, because the live ABS SDMX structure is exposed under the
+  `DS_`-prefixed id.
 
 `variant`, `geography`, and `frequency` are validated against the catalogue entry. For ABS
 datasets, populated variants can be literal SDMX keys or partial fragments that are completed
@@ -202,6 +273,7 @@ calling `search_datasets` first.
 | `ausecon://catalogue` | Flat index of every curated ABS and RBA entry (id, source, name, description, category, frequency, tags). |
 | `ausecon://abs/{dataflow_id}` | Full curated catalogue entry for a single ABS dataflow (e.g. `ausecon://abs/CPI`). |
 | `ausecon://rba/{table_id}` | Full curated catalogue entry for a single RBA statistical table (e.g. `ausecon://rba/g1`). |
+| `ausecon://concepts` | Index of every curated semantic shortcut with its resolved source, dataset id, variant, frequencies, and geographies. |
 
 All resources are read-only, served as `application/json`, and sourced
 from the static curated catalogue — no network calls are made to
@@ -209,7 +281,7 @@ render them.
 
 ## Prompts
 
-The server registers six prompt templates that chain the existing
+The server registers eight prompt templates that chain the existing
 tools into common economist workflows. Clients such as Claude Desktop
 surface these as slash-commands.
 
@@ -220,6 +292,8 @@ surface these as slash-commands.
 | `macro_snapshot` | `as_of: str \| None` | Assembles a compact snapshot table of cash rate, headline CPI, trimmed-mean CPI, and real GDP growth. |
 | `living_costs_vs_cpi` | `start: str \| None` | Compares Selected Living Cost Indexes across household types against headline CPI to highlight cost-of-living divergence. |
 | `construction_pipeline` | `last_n: int = 8` | Summarises construction pipeline strength across total, engineering, and residential/non-residential building activity. |
+| `labour_slack_snapshot` | `last_n: int = 12` | Reads `unemployment_rate` and `underemployment_rate` and narrates the combined slack signal. |
+| `yield_curve_snapshot` | `last_n: int = 60` | Reads the 3-year and 10-year AGS yields and describes the curve shape and recent shift. |
 | `discover_dataset` | `topic: str` | Runs `search_datasets` and `list_rba_tables` for the topic, then recommends the top two candidates. |
 
 Each tool is also annotated with `readOnlyHint` and `openWorldHint` so

--- a/docs/superpowers/plans/2026-04-19-semantic-layer-expansion-tranche-a.md
+++ b/docs/superpowers/plans/2026-04-19-semantic-layer-expansion-tranche-a.md
@@ -1,0 +1,774 @@
+# Semantic Layer Expansion Tranche A Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand `get_economic_series` from 4 to 16 stable semantic shortcuts by implementing the Tranche A backlog with explicit, audited ABS keys and RBA series mappings.
+
+**Architecture:** Keep the semantic layer thin. Populate existing catalogue entries with literal ABS keys or explicit RBA `series_ids`, then extend `CURATED_SHORTCUTS` in the resolver so `get_economic_series` remains a small source-aware routing layer over existing ABS and RBA providers. For tenor yields, use `f17` zero-coupon tenor series rather than `f16` bond-line series; for `housing_credit`, deliberately return the two seasonally adjusted housing-credit components because `d2` does not expose a single clean total-housing series in the current curated slice.
+
+**Tech Stack:** Python 3.10+, FastMCP, httpx, pytest, Ruff
+
+---
+
+## Locked Mapping Decisions
+
+These defaults should be treated as implementation decisions for Tranche A, not open questions:
+
+| Concept | Dataset | Variant | Default mapping |
+| --- | --- | --- | --- |
+| `employment` | `LF` | `employment` | `M3.3.1599.20.AUS.M` |
+| `unemployment_rate` | `LF` | `unemployment_rate` | `M13.3.1599.20.AUS.M` |
+| `participation_rate` | `LF` | `participation_rate` | `M12.3.1599.20.AUS.M` |
+| `wage_growth` | `WPI` | `headline_wpi` | `3.THRPEB.7.TOT.20.AUS.Q` |
+| `trade_balance` | `ITGS` | `trade_balance` | `M1.170.20.AUS.M` |
+| `weighted_median_inflation` | `g1` | `weighted_median` | `GCPIOCPMWMYP` |
+| `monthly_inflation` | `g4` | `headline_monthly` | `GCPIAGSAMP` |
+| `aud_usd` | `f11` | `aud_usd` | `FXRUSD` |
+| `trade_weighted_index` | `f11` | `twi` | `FXRTWI` |
+| `government_bond_yield_3y` | `f17` | `ags_3y` | `FZCY300D` |
+| `government_bond_yield_10y` | `f17` | `ags_10y` | `FZCY1000D` |
+| `housing_credit` | `d2` | `housing` | `DLCACOHS`, `DLCACIHS` |
+
+### Tranche B Reference Defaults
+
+These defaults are locked for planning consistency, but they are not part of the executable scope of this Tranche A implementation plan. They should be reused when the Tranche B implementation plan is written.
+
+| Concept | Dataset | Variant | Default mapping |
+| --- | --- | --- | --- |
+| `business_credit` | `d2` | `business` | `DLCACBS` |
+| `current_account_balance` | `BOP` | `current_account` | `1.100.20.Q` |
+| `underemployment_rate` | `LF_UNDER` | `headline_underemployment` | `M23.3.1599.20.AUS.M` |
+| `hours_worked` | `LF_HOURS` | `headline_hours` | `M18.3.1599.TOT.20.AUS.M` |
+| `job_vacancies` | `JV` | `headline_vacancies` | `M1.7.TOT.20.AUS.Q` |
+| `mortgage_rate` | `f6` | `owner_occupier_variable` | `FLRHOOVA` |
+| `business_lending_rate` | `f7` | `small_business_indicator` | `FLRBFOSBT` |
+| `population` | `ERP_Q` | `headline_population` | `1.3.TOT.AUS.Q` |
+| `inflation_expectations` | `g3` | `consumer` | `GCONEXP` |
+| `producer_price_inflation` | `PPI_FD` | `producer` | `3.TOT.TOT.TOTXE.Q` |
+| `household_spending` | `HSI_M` | `headline_spending` | `7.TOT.CUR.20.AUS.M` |
+| `commodity_prices` | `i2` | `rba_commodity_index` | `GRCPAISDR` |
+
+Tranche B notes:
+
+- `producer_price_inflation` is locked to `PPI_FD`, not `PPI`, because the final-demand year-ended series is the cleaner headline producer-price default.
+- `household_spending` is locked to the seasonally adjusted current-price total because the current `HSI_M` slice does not expose a clean Australia-total chain-volume series under the same semantic surface.
+- `commodity_prices` is locked to the all-items SDR index so the default is less mechanically driven by AUD movements.
+
+## File Map
+
+- Modify: `src/ausecon_mcp/catalogue/abs.py`
+  Purpose: populate `LF`, `WPI`, and `ITGS` variants used by the new ABS semantic shortcuts.
+- Modify: `src/ausecon_mcp/catalogue/rba.py`
+  Purpose: populate `g1`, `g4`, `f11`, `f17`, and `d2` variants used by the new RBA semantic shortcuts.
+- Modify: `src/ausecon_mcp/catalogue/resolver.py`
+  Purpose: extend `CURATED_SHORTCUTS` so the new concept names resolve deterministically.
+- Modify: `tests/test_resolver.py`
+  Purpose: lock the resolver contract for new ABS and RBA shortcuts and update shortcut-coverage assertions.
+- Modify: `tests/test_server.py`
+  Purpose: verify `AuseconService.get_economic_series()` forwards the expected ABS keys and RBA series lists.
+- Create: `integration_tests/test_semantic_live.py`
+  Purpose: add live smoke tests over representative semantic shortcuts so drift in upstream mappings is visible.
+- Modify: `README.md`
+  Purpose: document the expanded semantic surface and the exact default mappings.
+- Modify: `docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md`
+  Purpose: record the implementation choice to use `f17` for tenor yields and a two-series default for `housing_credit`.
+
+### Task 1: Add failing tests for the new ABS semantic shortcuts
+
+**Files:**
+- Modify: `tests/test_resolver.py`
+- Modify: `tests/test_server.py`
+
+- [ ] **Step 1: Add resolver tests for the new ABS defaults**
+
+Insert the following parametrised test block into `tests/test_resolver.py` near the existing shortcut tests:
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("concept", "dataset_id", "abs_key", "variant"),
+    [
+        ("employment", "LF", "M3.3.1599.20.AUS.M", "employment"),
+        ("unemployment_rate", "LF", "M13.3.1599.20.AUS.M", "unemployment_rate"),
+        ("participation_rate", "LF", "M12.3.1599.20.AUS.M", "participation_rate"),
+        ("wage_growth", "WPI", "3.THRPEB.7.TOT.20.AUS.Q", "headline_wpi"),
+        ("trade_balance", "ITGS", "M1.170.20.AUS.M", "trade_balance"),
+    ],
+)
+async def test_resolve_abs_tranche_a_shortcuts_default_to_expected_keys(
+    concept: str,
+    dataset_id: str,
+    abs_key: str,
+    variant: str,
+) -> None:
+    result = await resolve(concept)
+
+    assert result.source == "abs"
+    assert result.dataset_id == dataset_id
+    assert result.abs_key == abs_key
+    assert result.variant == variant
+```
+
+Also replace the current shortcut coverage assertion with this exact set:
+
+```python
+def test_curated_shortcuts_cover_semantic_tranche_a_concepts() -> None:
+    assert set(CURATED_SHORTCUTS) == {
+        "aud_usd",
+        "cash_rate_target",
+        "employment",
+        "gdp_growth",
+        "government_bond_yield_10y",
+        "government_bond_yield_3y",
+        "headline_cpi",
+        "housing_credit",
+        "monthly_inflation",
+        "participation_rate",
+        "trade_balance",
+        "trade_weighted_index",
+        "trimmed_mean_inflation",
+        "unemployment_rate",
+        "wage_growth",
+        "weighted_median_inflation",
+    }
+```
+
+- [ ] **Step 2: Add service forwarding tests for the new ABS defaults**
+
+Insert the following block into `tests/test_server.py` near the existing `get_economic_series` service tests:
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("concept", "dataset_id", "key"),
+    [
+        ("employment", "LF", "M3.3.1599.20.AUS.M"),
+        ("unemployment_rate", "LF", "M13.3.1599.20.AUS.M"),
+        ("participation_rate", "LF", "M12.3.1599.20.AUS.M"),
+        ("wage_growth", "WPI", "3.THRPEB.7.TOT.20.AUS.Q"),
+        ("trade_balance", "ITGS", "M1.170.20.AUS.M"),
+    ],
+)
+async def test_service_forwards_default_abs_keys_for_tranche_a_shortcuts(
+    concept: str,
+    dataset_id: str,
+    key: str,
+) -> None:
+    abs_provider = StubABSProvider()
+    service = AuseconService(abs_provider=abs_provider, rba_provider=StubRBAProvider())
+
+    await service.get_economic_series(concept)
+
+    assert abs_provider.last_get_data_kwargs is not None
+    assert abs_provider.last_get_data_kwargs["dataflow_id"] == dataset_id
+    assert abs_provider.last_get_data_kwargs["key"] == key
+```
+
+- [ ] **Step 3: Run the targeted tests and confirm they fail**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_resolver.py tests/test_server.py -k "employment or unemployment_rate or participation_rate or wage_growth or trade_balance or semantic_tranche_a" -v
+```
+
+Expected: `FAIL` because the new concepts are not yet present in `CURATED_SHORTCUTS`, and the shortcut coverage assertion still reflects the four-concept baseline.
+
+- [ ] **Step 4: Populate the ABS catalogue and resolver**
+
+Update `src/ausecon_mcp/catalogue/abs.py` with these exact variant definitions:
+
+```python
+"WPI": {
+    "id": "WPI",
+    "source": "abs",
+    "name": "Wage Price Index",
+    "description": "Wage inflation across sectors and industries in Australia.",
+    "frequency": "Quarterly",
+    "category": "prices_inflation",
+    "aliases": [
+        "wpi",
+        "wage price index",
+        "wage inflation",
+    ],
+    "tags": [
+        "wages",
+        "labour costs",
+        "earnings",
+    ],
+    "frequencies": ["Q"],
+    "geographies": ["national"],
+    "variants": [
+        {
+            "name": "headline_wpi",
+            "aliases": ["wage growth", "headline wage growth", "year-ended wage growth"],
+            "abs_key": "3.THRPEB.7.TOT.20.AUS.Q",
+        },
+    ],
+    "audit": {
+        "last_audited": "2026-04-18",
+        "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/WPI/latest",
+        "upstream_title": "Wage Price Index",
+    },
+},
+```
+
+Replace the existing `variants` list inside `LF` with:
+
+```python
+"variants": [
+    {
+        "name": "employment",
+        "aliases": ["employed persons"],
+        "abs_key": "M3.3.1599.20.AUS.M",
+    },
+    {
+        "name": "unemployment_rate",
+        "aliases": ["unemployment", "jobless rate"],
+        "abs_key": "M13.3.1599.20.AUS.M",
+    },
+    {
+        "name": "participation_rate",
+        "aliases": ["participation"],
+        "abs_key": "M12.3.1599.20.AUS.M",
+    },
+],
+```
+
+Replace the existing `variants` list inside `ITGS` with:
+
+```python
+"variants": [
+    {"name": "exports", "aliases": [], "abs_key": None},
+    {"name": "imports", "aliases": [], "abs_key": None},
+    {
+        "name": "trade_balance",
+        "aliases": ["net exports"],
+        "abs_key": "M1.170.20.AUS.M",
+    },
+],
+```
+
+Then extend `CURATED_SHORTCUTS` in `src/ausecon_mcp/catalogue/resolver.py` with these entries:
+
+```python
+CURATED_SHORTCUTS: dict[str, dict[str, Any]] = {
+    "cash_rate_target": {"source": "rba", "dataset_id": "a2", "variant": "target"},
+    "headline_cpi": {"source": "abs", "dataset_id": "CPI", "variant": "headline"},
+    "trimmed_mean_inflation": {"source": "rba", "dataset_id": "g1", "variant": "trimmed_mean"},
+    "gdp_growth": {"source": "abs", "dataset_id": "ANA_AGG", "variant": "gdp_growth"},
+    "employment": {"source": "abs", "dataset_id": "LF", "variant": "employment"},
+    "unemployment_rate": {"source": "abs", "dataset_id": "LF", "variant": "unemployment_rate"},
+    "participation_rate": {"source": "abs", "dataset_id": "LF", "variant": "participation_rate"},
+    "wage_growth": {"source": "abs", "dataset_id": "WPI", "variant": "headline_wpi"},
+    "trade_balance": {"source": "abs", "dataset_id": "ITGS", "variant": "trade_balance"},
+}
+```
+
+- [ ] **Step 5: Re-run the targeted ABS tests and confirm they pass**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_resolver.py tests/test_server.py -k "employment or unemployment_rate or participation_rate or wage_growth or trade_balance or semantic_tranche_a" -v
+```
+
+Expected: `PASS` for the new ABS resolver and service tests.
+
+- [ ] **Step 6: Commit the ABS semantic shortcut tranche**
+
+```bash
+git add src/ausecon_mcp/catalogue/abs.py src/ausecon_mcp/catalogue/resolver.py tests/test_resolver.py tests/test_server.py
+git commit -m "feat: add abs semantic shortcut tranche"
+```
+
+### Task 2: Add failing tests and implementation for RBA inflation and FX shortcuts
+
+**Files:**
+- Modify: `tests/test_resolver.py`
+- Modify: `tests/test_server.py`
+- Modify: `src/ausecon_mcp/catalogue/rba.py`
+- Modify: `src/ausecon_mcp/catalogue/resolver.py`
+
+- [ ] **Step 1: Add resolver tests for weighted median, monthly inflation, and FX**
+
+Insert this block into `tests/test_resolver.py` after the ABS tranche tests:
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("concept", "dataset_id", "series_ids", "variant"),
+    [
+        ("weighted_median_inflation", "g1", ["GCPIOCPMWMYP"], "weighted_median"),
+        ("monthly_inflation", "g4", ["GCPIAGSAMP"], "headline_monthly"),
+        ("aud_usd", "f11", ["FXRUSD"], "aud_usd"),
+        ("trade_weighted_index", "f11", ["FXRTWI"], "twi"),
+    ],
+)
+async def test_resolve_rba_inflation_and_fx_tranche_defaults(
+    concept: str,
+    dataset_id: str,
+    series_ids: list[str],
+    variant: str,
+) -> None:
+    result = await resolve(concept)
+
+    assert result.source == "rba"
+    assert result.dataset_id == dataset_id
+    assert result.rba_series_ids == series_ids
+    assert result.variant == variant
+```
+
+- [ ] **Step 2: Add service forwarding tests for the same RBA concepts**
+
+Insert this block into `tests/test_server.py`:
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("concept", "table_id", "series_ids"),
+    [
+        ("weighted_median_inflation", "g1", ["GCPIOCPMWMYP"]),
+        ("monthly_inflation", "g4", ["GCPIAGSAMP"]),
+        ("aud_usd", "f11", ["FXRUSD"]),
+        ("trade_weighted_index", "f11", ["FXRTWI"]),
+    ],
+)
+async def test_service_forwards_default_rba_series_ids_for_inflation_and_fx_tranche(
+    concept: str,
+    table_id: str,
+    series_ids: list[str],
+) -> None:
+    rba = StubRBAProvider()
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=rba)
+
+    await service.get_economic_series(concept)
+
+    assert rba.last_get_table_kwargs is not None
+    assert rba.last_get_table_kwargs["table_id"] == table_id
+    assert rba.last_get_table_kwargs["series_ids"] == series_ids
+```
+
+- [ ] **Step 3: Run the targeted tests and confirm they fail**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_resolver.py tests/test_server.py -k "weighted_median_inflation or monthly_inflation or aud_usd or trade_weighted_index" -v
+```
+
+Expected: `FAIL` because the new shortcuts do not yet exist, `g1.weighted_median` is still unpopulated, and `g4` / `f11` currently have no variants.
+
+- [ ] **Step 4: Populate the RBA catalogue entries and resolver shortcuts**
+
+Update `src/ausecon_mcp/catalogue/rba.py` with the following exact variant definitions:
+
+Replace the existing `variants` list inside `g1` with:
+
+```python
+"variants": [
+    {
+        "name": "headline",
+        "aliases": ["headline cpi", "cpi"],
+        "rba_series_ids": ["GCPIAG"],
+    },
+    {
+        "name": "trimmed_mean",
+        "aliases": ["core", "trimmed mean inflation"],
+        "rba_series_ids": ["GCPIOCPMTMYP"],
+    },
+    {
+        "name": "weighted_median",
+        "aliases": ["weighted median inflation"],
+        "rba_series_ids": ["GCPIOCPMWMYP"],
+    },
+],
+```
+
+Replace the existing `variants` list inside `g4` with:
+
+```python
+"variants": [
+    {
+        "name": "headline_monthly",
+        "aliases": ["monthly inflation", "monthly cpi"],
+        "rba_series_ids": ["GCPIAGSAMP"],
+    },
+],
+```
+
+Replace the existing `variants` list inside `f11` with:
+
+```python
+"variants": [
+    {
+        "name": "aud_usd",
+        "aliases": ["a$1=usd", "aud usd", "aud/usd"],
+        "rba_series_ids": ["FXRUSD"],
+    },
+    {
+        "name": "twi",
+        "aliases": ["trade weighted index", "trade-weighted index"],
+        "rba_series_ids": ["FXRTWI"],
+    },
+],
+```
+
+Then extend `CURATED_SHORTCUTS` in `src/ausecon_mcp/catalogue/resolver.py` with:
+
+```python
+    "weighted_median_inflation": {
+        "source": "rba",
+        "dataset_id": "g1",
+        "variant": "weighted_median",
+    },
+    "monthly_inflation": {"source": "rba", "dataset_id": "g4", "variant": "headline_monthly"},
+    "aud_usd": {"source": "rba", "dataset_id": "f11", "variant": "aud_usd"},
+    "trade_weighted_index": {"source": "rba", "dataset_id": "f11", "variant": "twi"},
+```
+
+- [ ] **Step 5: Re-run the targeted tests and confirm they pass**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_resolver.py tests/test_server.py -k "weighted_median_inflation or monthly_inflation or aud_usd or trade_weighted_index" -v
+```
+
+Expected: `PASS` for the new RBA inflation and FX tests.
+
+- [ ] **Step 6: Commit the RBA inflation and FX shortcut tranche**
+
+```bash
+git add src/ausecon_mcp/catalogue/rba.py src/ausecon_mcp/catalogue/resolver.py tests/test_resolver.py tests/test_server.py
+git commit -m "feat: add rba inflation and fx semantic shortcuts"
+```
+
+### Task 3: Implement yield and housing-credit semantics with explicit design notes
+
+**Files:**
+- Modify: `tests/test_resolver.py`
+- Modify: `tests/test_server.py`
+- Modify: `src/ausecon_mcp/catalogue/rba.py`
+- Modify: `src/ausecon_mcp/catalogue/resolver.py`
+- Modify: `docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md`
+
+- [ ] **Step 1: Add failing tests for the yield and housing-credit concepts**
+
+Insert this block into `tests/test_resolver.py`:
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("concept", "dataset_id", "series_ids", "variant"),
+    [
+        ("government_bond_yield_3y", "f17", ["FZCY300D"], "ags_3y"),
+        ("government_bond_yield_10y", "f17", ["FZCY1000D"], "ags_10y"),
+        ("housing_credit", "d2", ["DLCACOHS", "DLCACIHS"], "housing"),
+    ],
+)
+async def test_resolve_rba_yield_and_credit_tranche_defaults(
+    concept: str,
+    dataset_id: str,
+    series_ids: list[str],
+    variant: str,
+) -> None:
+    result = await resolve(concept)
+
+    assert result.source == "rba"
+    assert result.dataset_id == dataset_id
+    assert result.rba_series_ids == series_ids
+    assert result.variant == variant
+```
+
+Insert this block into `tests/test_server.py`:
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("concept", "table_id", "series_ids"),
+    [
+        ("government_bond_yield_3y", "f17", ["FZCY300D"]),
+        ("government_bond_yield_10y", "f17", ["FZCY1000D"]),
+        ("housing_credit", "d2", ["DLCACOHS", "DLCACIHS"]),
+    ],
+)
+async def test_service_forwards_default_rba_series_ids_for_yield_and_credit_tranche(
+    concept: str,
+    table_id: str,
+    series_ids: list[str],
+) -> None:
+    rba = StubRBAProvider()
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=rba)
+
+    await service.get_economic_series(concept)
+
+    assert rba.last_get_table_kwargs is not None
+    assert rba.last_get_table_kwargs["table_id"] == table_id
+    assert rba.last_get_table_kwargs["series_ids"] == series_ids
+```
+
+- [ ] **Step 2: Run the targeted tests and confirm they fail**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_resolver.py tests/test_server.py -k "government_bond_yield_3y or government_bond_yield_10y or housing_credit" -v
+```
+
+Expected: `FAIL` because the concepts are absent from `CURATED_SHORTCUTS`, `f17` has no variants, and `d2.housing` is still unpopulated.
+
+- [ ] **Step 3: Populate the `f17` and `d2` catalogue variants and wire the resolver**
+
+Update `src/ausecon_mcp/catalogue/rba.py`:
+
+Replace the existing `variants` list inside `f17` with:
+
+```python
+"variants": [
+    {
+        "name": "ags_3y",
+        "aliases": ["3 year", "3-year", "3y"],
+        "rba_series_ids": ["FZCY300D"],
+    },
+    {
+        "name": "ags_10y",
+        "aliases": ["10 year", "10-year", "10y"],
+        "rba_series_ids": ["FZCY1000D"],
+    },
+],
+```
+
+Replace the existing `variants` list inside `d2` with:
+
+```python
+"variants": [
+    {
+        "name": "housing",
+        "aliases": ["housing credit"],
+        "rba_series_ids": ["DLCACOHS", "DLCACIHS"],
+    },
+    {"name": "business", "aliases": ["business credit"], "rba_series_ids": None},
+    {"name": "household", "aliases": ["household credit"], "rba_series_ids": None},
+],
+```
+
+Then extend `CURATED_SHORTCUTS` in `src/ausecon_mcp/catalogue/resolver.py`:
+
+```python
+    "government_bond_yield_3y": {"source": "rba", "dataset_id": "f17", "variant": "ags_3y"},
+    "government_bond_yield_10y": {"source": "rba", "dataset_id": "f17", "variant": "ags_10y"},
+    "housing_credit": {"source": "rba", "dataset_id": "d2", "variant": "housing"},
+```
+
+- [ ] **Step 4: Record the design choice in the semantic design spec**
+
+Add this note to `docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md` immediately after the ranked backlog table:
+
+```md
+## Tranche A Implementation Notes
+
+- `government_bond_yield_3y` and `government_bond_yield_10y` should resolve to `RBA f17`, not `f16`. `f16` is bond-line data keyed to individual securities, while the semantic layer needs clean tenor defaults.
+- `housing_credit` should resolve to the two seasonally adjusted housing-credit component series in `d2` (`DLCACOHS`, `DLCACIHS`) because the current curated slice does not expose a single clean headline housing-credit total.
+```
+
+- [ ] **Step 5: Re-run the targeted tests and confirm they pass**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_resolver.py tests/test_server.py -k "government_bond_yield_3y or government_bond_yield_10y or housing_credit" -v
+```
+
+Expected: `PASS` for the yield and housing-credit tests.
+
+- [ ] **Step 6: Commit the yield and housing-credit tranche**
+
+```bash
+git add src/ausecon_mcp/catalogue/rba.py src/ausecon_mcp/catalogue/resolver.py tests/test_resolver.py tests/test_server.py docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md
+git commit -m "feat: add yield and housing credit semantic shortcuts"
+```
+
+### Task 4: Add live smoke coverage for the semantic layer
+
+**Files:**
+- Create: `integration_tests/test_semantic_live.py`
+
+- [ ] **Step 1: Add a live semantic smoke-test file**
+
+Create `integration_tests/test_semantic_live.py` with this exact content:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from ausecon_mcp.providers.abs import ABSProvider
+from ausecon_mcp.providers.rba import RBAProvider
+from ausecon_mcp.server import AuseconService
+
+pytestmark = pytest.mark.asyncio
+
+
+def _service() -> AuseconService:
+    return AuseconService(abs_provider=ABSProvider(), rba_provider=RBAProvider())
+
+
+async def test_semantic_unemployment_rate_live_returns_observations() -> None:
+    service = _service()
+
+    result = await service.get_economic_series("unemployment_rate", start="2024-01")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "LF"
+    assert result["observations"]
+
+
+async def test_semantic_wage_growth_live_returns_observations() -> None:
+    service = _service()
+
+    result = await service.get_economic_series("wage_growth", start="2023-Q1")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "WPI"
+    assert result["observations"]
+
+
+async def test_semantic_monthly_inflation_live_returns_expected_series() -> None:
+    service = _service()
+
+    result = await service.get_economic_series("monthly_inflation", start="2024-01-01")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "g4"
+    assert {item["series_id"] for item in result["series"]} == {"GCPIAGSAMP"}
+
+
+async def test_semantic_government_bond_yield_10y_live_returns_expected_series() -> None:
+    service = _service()
+
+    result = await service.get_economic_series("government_bond_yield_10y", start="2024-01-01")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "f17"
+    assert {item["series_id"] for item in result["series"]} == {"FZCY1000D"}
+
+
+async def test_semantic_housing_credit_live_returns_two_series() -> None:
+    service = _service()
+
+    result = await service.get_economic_series("housing_credit", start="2024-01-01")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "d2"
+    assert {item["series_id"] for item in result["series"]} == {"DLCACOHS", "DLCACIHS"}
+```
+
+- [ ] **Step 2: Run the live semantic smoke tests**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest integration_tests/test_semantic_live.py -v
+```
+
+Expected: `PASS`. If a live test fails because upstream changed, stop and update the catalogue mapping before continuing.
+
+- [ ] **Step 3: Commit the live smoke coverage**
+
+```bash
+git add integration_tests/test_semantic_live.py
+git commit -m "test: add live semantic smoke coverage"
+```
+
+### Task 5: Update the public documentation and run the full verification suite
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Expand the supported semantic concepts section in the README**
+
+Replace the current four-item semantic list in `README.md` with this exact list:
+
+```md
+`get_economic_series` currently supports:
+
+- `cash_rate_target`
+- `headline_cpi`
+- `trimmed_mean_inflation`
+- `gdp_growth`
+- `employment`
+- `unemployment_rate`
+- `participation_rate`
+- `wage_growth`
+- `trade_balance`
+- `weighted_median_inflation`
+- `monthly_inflation`
+- `aud_usd`
+- `trade_weighted_index`
+- `government_bond_yield_3y`
+- `government_bond_yield_10y`
+- `housing_credit`
+```
+
+Then replace the default-mapping bullet list with:
+
+```md
+By default, these currently resolve to the following narrowed series:
+
+- `cash_rate_target` -> RBA `a2` cash rate target series (`ARBAMPCNCRT`)
+- `headline_cpi` -> ABS `CPI` all groups CPI index for Australia, quarterly (`1.10001.10.50.Q`)
+- `trimmed_mean_inflation` -> RBA `g1` year-ended trimmed mean inflation (`GCPIOCPMTMYP`)
+- `gdp_growth` -> ABS `ANA_AGG` quarterly real GDP growth (`M2.GPM.20.AUS.Q`)
+- `employment` -> ABS `LF` employed persons, seasonally adjusted (`M3.3.1599.20.AUS.M`)
+- `unemployment_rate` -> ABS `LF` unemployment rate, seasonally adjusted (`M13.3.1599.20.AUS.M`)
+- `participation_rate` -> ABS `LF` participation rate, seasonally adjusted (`M12.3.1599.20.AUS.M`)
+- `wage_growth` -> ABS `WPI` year-ended total hourly wage growth excluding bonuses, seasonally adjusted (`3.THRPEB.7.TOT.20.AUS.Q`)
+- `trade_balance` -> ABS `ITGS` balance on goods, seasonally adjusted (`M1.170.20.AUS.M`)
+- `weighted_median_inflation` -> RBA `g1` year-ended weighted median inflation (`GCPIOCPMWMYP`)
+- `monthly_inflation` -> RBA `g4` monthly inflation, seasonally adjusted (`GCPIAGSAMP`)
+- `aud_usd` -> RBA `f11` AUD/USD exchange rate (`FXRUSD`)
+- `trade_weighted_index` -> RBA `f11` trade-weighted index (`FXRTWI`)
+- `government_bond_yield_3y` -> RBA `f17` three-year zero-coupon yield (`FZCY300D`)
+- `government_bond_yield_10y` -> RBA `f17` ten-year zero-coupon yield (`FZCY1000D`)
+- `housing_credit` -> RBA `d2` seasonally adjusted owner-occupier and investor housing credit (`DLCACOHS`, `DLCACIHS`)
+```
+
+- [ ] **Step 2: Run the focused documentation and hygiene tests**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_repository_hygiene.py tests/test_resolver.py tests/test_server.py integration_tests/test_semantic_live.py -v
+```
+
+Expected: `PASS`.
+
+- [ ] **Step 3: Run the full repository verification suite**
+
+Run:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run pytest
+env UV_CACHE_DIR=.uv-cache uv run ruff check src tests integration_tests
+```
+
+Expected: both commands finish cleanly with no test failures and no Ruff findings.
+
+- [ ] **Step 4: Commit the documentation and final verification pass**
+
+```bash
+git add README.md
+git commit -m "docs: document semantic shortcut tranche a"
+```
+
+## Completion Criteria
+
+The implementation is complete when all of the following are true:
+
+- `get_economic_series` supports 16 documented shortcuts: the original 4 plus the 12 Tranche A additions.
+- All new shortcuts resolve without fallback ambiguity.
+- `government_bond_yield_3y` and `government_bond_yield_10y` resolve to `f17`, not `f16`.
+- `housing_credit` deliberately returns two seasonally adjusted series from `d2`.
+- `tests/test_resolver.py`, `tests/test_server.py`, and `integration_tests/test_semantic_live.py` all pass.
+- `README.md` and the semantic design spec describe the implemented mappings accurately.

--- a/docs/superpowers/plans/2026-04-19-semantic-layer-expansion-tranches-ab.md
+++ b/docs/superpowers/plans/2026-04-19-semantic-layer-expansion-tranches-ab.md
@@ -1,0 +1,174 @@
+# Semantic Layer Expansion Tranches A+B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand `get_economic_series` from 4 to 28 stable semantic shortcuts by implementing the combined Tranche A and Tranche B backlog with explicit, audited ABS keys and RBA series mappings.
+
+**Architecture:** Keep the semantic layer intentionally thin. Populate existing catalogue entries with literal ABS keys or explicit RBA `series_ids`, extend `CURATED_SHORTCUTS` so the semantic names resolve deterministically, and add a small ABS structure-resolution hardening path for entries whose live SDMX structure ID differs from the dataflow ID. Do not add new MCP tools, alter response shapes, or broaden the provider architecture.
+
+**Tech Stack:** Python 3.10+, FastMCP, httpx, pytest, Ruff
+
+---
+
+## Summary
+
+Replace the Tranche A-only rollout with a single combined implementation covering both Tranche A and Tranche B semantic concepts in one pass.
+
+After implementation, `get_economic_series` will support:
+
+- the 4 currently shipped concepts
+- 12 Tranche A additions
+- 12 Tranche B additions
+
+Public interface impact:
+
+- no change to the `get_economic_series` tool signature
+- no change to the normalised response shape
+- one internal interface addition: support an optional ABS catalogue `structure_id` so semantic resolution can fetch the correct SDMX structure when it differs from the dataflow ID
+
+## Locked Defaults
+
+Existing shipped defaults remain unchanged:
+
+- `cash_rate_target` -> `a2.target` -> `ARBAMPCNCRT`
+- `headline_cpi` -> `CPI.headline` -> `1.10001.10.50.Q`
+- `trimmed_mean_inflation` -> `g1.trimmed_mean` -> `GCPIOCPMTMYP`
+- `gdp_growth` -> `ANA_AGG.gdp_growth` -> `M2.GPM.20.AUS.Q`
+
+### Tranche A Defaults
+
+| Concept | Dataset | Variant | Default mapping |
+| --- | --- | --- | --- |
+| `employment` | `LF` | `employment` | `M3.3.1599.20.AUS.M` |
+| `unemployment_rate` | `LF` | `unemployment_rate` | `M13.3.1599.20.AUS.M` |
+| `participation_rate` | `LF` | `participation_rate` | `M12.3.1599.20.AUS.M` |
+| `wage_growth` | `WPI` | `headline_wpi` | `3.THRPEB.7.TOT.20.AUS.Q` |
+| `trade_balance` | `ITGS` | `trade_balance` | `M1.170.20.AUS.M` |
+| `weighted_median_inflation` | `g1` | `weighted_median` | `GCPIOCPMWMYP` |
+| `monthly_inflation` | `g4` | `headline_monthly` | `GCPIAGSAMP` |
+| `aud_usd` | `f11` | `aud_usd` | `FXRUSD` |
+| `trade_weighted_index` | `f11` | `twi` | `FXRTWI` |
+| `government_bond_yield_3y` | `f17` | `ags_3y` | `FZCY300D` |
+| `government_bond_yield_10y` | `f17` | `ags_10y` | `FZCY1000D` |
+| `housing_credit` | `d2` | `housing` | `DLCACOHS`, `DLCACIHS` |
+
+### Tranche B Defaults
+
+| Concept | Dataset | Variant | Default mapping |
+| --- | --- | --- | --- |
+| `business_credit` | `d2` | `business` | `DLCACBS` |
+| `current_account_balance` | `BOP` | `current_account` | `1.100.20.Q` |
+| `underemployment_rate` | `LF_UNDER` | `headline_underemployment` | `M23.3.1599.20.AUS.M` |
+| `hours_worked` | `LF_HOURS` | `headline_hours` | `M18.3.1599.TOT.20.AUS.M` |
+| `job_vacancies` | `JV` | `headline_vacancies` | `M1.7.TOT.20.AUS.Q` |
+| `mortgage_rate` | `f6` | `owner_occupier_variable` | `FLRHOOVA` |
+| `business_lending_rate` | `f7` | `small_business_indicator` | `FLRBFOSBT` |
+| `population` | `ERP_Q` | `headline_population` | `1.3.TOT.AUS.Q` |
+| `inflation_expectations` | `g3` | `consumer` | `GCONEXP` |
+| `producer_price_inflation` | `PPI_FD` | `producer` | `3.TOT.TOT.TOTXE.Q` |
+| `household_spending` | `HSI_M` | `headline_spending` | `7.TOT.CUR.20.AUS.M` |
+| `commodity_prices` | `i2` | `rba_commodity_index` | `GRCPAISDR` |
+
+Locked choices that must not be reopened during implementation:
+
+- Use `f17`, not `f16`, for tenor yield concepts.
+- `housing_credit` returns two seasonally adjusted series from `d2`; do not derive an aggregate.
+- `business_credit` uses the broad seasonally adjusted business-credit series `DLCACBS`, not the narrower non-financial-business series.
+- `producer_price_inflation` uses `PPI_FD`, not `PPI`.
+- `household_spending` uses the seasonally adjusted current-price total because the current `HSI_M` slice does not expose a clean Australia-total chain-volume default.
+- `commodity_prices` uses the all-items SDR index to avoid baking AUD moves into the default commodity-price concept.
+
+## Key Implementation Changes
+
+### Resolver and ABS Structure Hardening
+
+- Extend `CURATED_SHORTCUTS` to include all 24 new Tranche A+B concept names.
+- Add an internal ABS structure-resolution helper, `resolve_abs_structure_id()`, parallel to `resolve_abs_dataflow_id()`.
+- Add an optional `structure_id` field on ABS catalogue entries; default behaviour remains “use the dataset ID”.
+- Set `LF_UNDER.structure_id = "DS_LF_UNDER"` and use that mapping whenever semantic resolution needs to fetch an ABS structure for key composition.
+- Keep `get_economic_series` unchanged externally; the structure-ID mapping is internal only.
+
+This hardening is required because `LF_UNDER` is a valid ABS dataflow but its live structure is exposed under `DS_LF_UNDER`, not `LF_UNDER`. Without this change, future semantic calls that require ABS structure composition for `LF_UNDER` will fail even though the dataflow itself is correct.
+
+### ABS Catalogue Population
+
+Populate only the ABS variants required by Tranches A+B:
+
+- `LF`: `employment`, `unemployment_rate`, `participation_rate`
+- `WPI`: `headline_wpi`
+- `ITGS`: `trade_balance`
+- `LF_UNDER`: `headline_underemployment`
+- `LF_HOURS`: `headline_hours`
+- `JV`: `headline_vacancies`
+- `ERP_Q`: `headline_population`
+- `BOP`: `current_account`
+- `PPI_FD`: `producer`
+- `HSI_M`: `headline_spending`
+
+Do not opportunistically fill unrelated placeholder variants in the same pass unless they are needed by Tranches A+B.
+
+### RBA Catalogue Population
+
+Populate only the RBA variants required by Tranches A+B:
+
+- `g1`: `weighted_median`
+- `g4`: `headline_monthly`
+- `f11`: `aud_usd`, `twi`
+- `f17`: `ags_3y`, `ags_10y`
+- `d2`: `housing`, `business`
+- `f6`: `owner_occupier_variable`
+- `f7`: `small_business_indicator`
+- `g3`: `consumer`
+- `i2`: `rba_commodity_index`
+
+### Tests and Documentation
+
+Expand tests in three layers:
+
+- resolver tests for every new concept, asserting the expected dataset, variant, and ABS key or RBA `series_ids`
+- service tests asserting that `AuseconService.get_economic_series()` forwards the exact keys and `series_ids` to the underlying providers
+- live semantic smoke tests covering both tranches, including `underemployment_rate`, `hours_worked`, `current_account_balance`, `mortgage_rate`, `population`, and `commodity_prices`, in addition to the Tranche A live cases
+
+Update README and semantic design docs so they:
+
+- list all 28 supported shortcuts
+- document the grouped default mappings
+- explicitly explain the `f17` yield choice, the two-series `housing_credit` default, the `PPI_FD` producer-price choice, and the `LF_UNDER` structure-ID nuance
+
+## Test Plan
+
+The implementation is complete only when all of the following pass:
+
+- resolver tests for all 24 new concepts
+- service forwarding tests for all 24 new concepts
+- helper tests for `resolve_abs_structure_id()`:
+  - unknown key passes through unchanged
+  - a catalogue entry without `structure_id` falls back to the dataset ID
+  - `LF_UNDER` returns `DS_LF_UNDER`
+- one `LF_UNDER` semantic resolution test confirming structure-based resolution works with the mapped structure ID rather than failing on a 404
+- live semantic smoke tests for both tranches
+- existing repository hygiene tests after README updates
+- full `pytest` suite
+- full Ruff check
+
+Representative live scenarios that should be present:
+
+- `unemployment_rate`
+- `wage_growth`
+- `monthly_inflation`
+- `government_bond_yield_10y`
+- `housing_credit`
+- `current_account_balance`
+- `underemployment_rate`
+- `mortgage_rate`
+- `population`
+- `commodity_prices`
+
+## Assumptions and Defaults
+
+- No new MCP tools, prompts, or response-shape changes are part of this plan.
+- `last_n` support for `get_economic_series` is not part of this plan.
+- No provider base-class refactor is part of this plan.
+- No derived concepts are included beyond the locked multi-series `housing_credit` default.
+- The implementation remains narrowly scoped to ABS + RBA only.
+- This combined plan supersedes the Tranche A-only plan for execution purposes.

--- a/docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md
@@ -1,0 +1,146 @@
+# Semantic Layer Expansion Design
+
+**Goal:** Define a ranked backlog for expanding `get_economic_series` beyond the four currently shipped shortcuts.
+
+**Current shipped concepts:** `cash_rate_target`, `headline_cpi`, `trimmed_mean_inflation`, `gdp_growth`
+
+## Ranking Principle
+
+The ranking balances:
+
+1. usefulness to a broad economist audience
+2. closeness to the current ABS + RBA catalogue
+3. fit with the current thin resolver design
+
+The list deliberately prefers source-native concepts over computed transforms.
+
+## Work Codes
+
+- `C` — existing catalogue entry is present; populate the default `abs_key` or `rba_series_ids` and add the shortcut
+- `CR` — catalogue replacement or a new audited entry is required first
+- `S` — service-layer derived concept
+- `P` — provider or parser work required
+
+No concepts in this document currently require `P`.
+
+## Ranked Backlog
+
+| Rank | Concept | Recommended Target | Proposed Default Variant | Work | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `unemployment_rate` | `ABS LF` | `unemployment_rate` | `C` | Variant already exists in the catalogue; populate `abs_key`. |
+| 2 | `wage_growth` | `ABS WPI` | `headline_wpi` | `C` | Choose one canonical WPI series and document it. |
+| 3 | `participation_rate` | `ABS LF` | `participation_rate` | `C` | Same pattern as unemployment. |
+| 4 | `employment` | `ABS LF` | `employment` | `C` | Prefer a clean level concept before derived growth rates. |
+| 5 | `weighted_median_inflation` | `RBA g1` | `weighted_median` | `C` | Variant already declared; populate `rba_series_ids`. |
+| 6 | `monthly_inflation` | `RBA g4` | `headline_monthly` | `C` | Best near-term monthly inflation shortcut. |
+| 7 | `trade_balance` | `ABS ITGS` | `trade_balance` | `C` | Existing `ITGS` variant is the cleanest target. |
+| 8 | `government_bond_yield_10y` | `RBA f16` | `ags_10y` | `C` | Standard macro and market concept. |
+| 9 | `government_bond_yield_3y` | `RBA f16` | `ags_3y` | `C` | Natural pair with the 10-year series. |
+| 10 | `aud_usd` | `RBA f11` | `aud_usd` | `C` | Common FX shortcut. |
+| 11 | `trade_weighted_index` | `RBA f11` | `twi` | `C` | Very common in Australian macro work. |
+| 12 | `housing_credit` | `RBA d2` | `housing` | `C` | Use stock or outstanding credit, not flow lending. |
+| 13 | `business_credit` | `RBA d2` | `business` | `C` | Same pattern as housing credit. |
+| 14 | `current_account_balance` | `ABS BOP` | `current_account` | `C` | Canonical external-balance shortcut. |
+| 15 | `underemployment_rate` | `ABS LF_UNDER` | `headline_underemployment` | `C` | Choose the national seasonally adjusted default. |
+| 16 | `hours_worked` | `ABS LF_HOURS` | `headline_hours` | `C` | Valuable labour and activity bridge. |
+| 17 | `job_vacancies` | `ABS JV` | `headline_vacancies` | `C` | Strong labour-tightness indicator. |
+| 18 | `mortgage_rate` | `RBA f6` | `owner_occupier_variable` | `C` | Must choose and document the default loan product. |
+| 19 | `business_lending_rate` | `RBA f7` | `small_business_indicator` | `C` | Useful, but default-series choice matters. |
+| 20 | `population` | `ABS ERP_Q` | `headline_population` | `C` | Clean and broadly useful. |
+| 21 | `inflation_expectations` | `RBA g3` | `consumer` | `C` | Good concept, but the generic label is ambiguous without a default. |
+| 22 | `producer_price_inflation` | `ABS PPI` | `producer` | `C` | Could also use `PPI_FD`; choose one and stay consistent. |
+| 23 | `household_spending` | `ABS HSI_M` | `headline_spending` | `C` | High-value monthly activity concept. |
+| 24 | `commodity_prices` | `RBA i2` | `rba_commodity_index` | `C` | Highly relevant in Australia, though narrower than the top tranche. |
+| 25 | `state_final_demand` | `ABS ANA_SFD` | `national` | `C` | Valuable once geography pass-through is clear. |
+| 26 | `living_costs` | `ABS SLCI` | `employee` | `C` | Useful, but the default household type must be explicit. |
+| 27 | `household_consumption` | `ABS ANA_EXP` | `household_final_consumption` | `C` | Needs one clear national-accounts target series. |
+| 28 | `business_investment` | `ABS CAPEX` | `private_capex` | `C` | Decide whether this means CAPEX survey or national-accounts investment. |
+| 29 | `company_profits` | `ABS QBIS` | `profits` | `C` | Useful and already signposted in the catalogue. |
+| 30 | `labour_productivity` | `RBA h4` | `labour_productivity` | `C` | Requires explicit series mapping in the table. |
+| 31 | `unit_labour_costs` | `RBA h4` | `unit_labour_costs` | `C` | Same issue as labour productivity. |
+| 32 | `natural_increase` | `ABS ERP_COMP_Q` | `natural_increase` | `C` | Useful demographic macro input. |
+| 33 | `net_overseas_migration` | `ABS ERP_COMP_Q` | `net_overseas_migration` | `C` | Strong relevance in the Australian context. |
+| 34 | `deposit_rate` | `RBA f4.1` | `household_deposit_rate` | `C` | Lower priority than mortgage and business loan rates. |
+| 35 | `export_prices` | `ABS PPI` | `export` | `C` | Could alternatively map to `ITPI_EXP`; choose one canonical source. |
+| 36 | `import_prices` | `ABS PPI` | `import` | `C` | Same issue as export prices. |
+| 37 | `new_housing_lending` | `ABS LEND_HOUSING` | `owner_occupier` | `C` | Flow concept, distinct from housing credit outstanding. |
+| 38 | `new_business_lending` | `ABS LEND_BUSINESS` | `headline_business_commitments` | `C` | Flow concept for business finance. |
+| 39 | `dwelling_approvals` | `ABS new audited building approvals entry` | `headline_approvals` | `CR` | Current catalogue does not have a clean approvals entry. |
+| 40 | `dwelling_prices` | `ABS replacement for ceased RPPI entry` | `headline_dwelling_prices` | `CR` | Current `RPPI` entry is ceased. |
+| 41 | `retail_trade` | `ABS replacement for ceased RT entry` | `headline_retail_trade` | `CR` | Current `RT` entry is ceased. |
+| 42 | `gdp_per_capita` | `ABS ANA_AGG` + `ABS ERP_Q` | `derived` | `S` | Needs service-layer computation. |
+| 43 | `yield_curve_slope` | `RBA f16` | `10y_minus_3y` | `S` | Very useful, but clearly derived. |
+| 44 | `real_cash_rate` | `RBA a2` + inflation concept | `cash_minus_trimmed_mean` | `S` | Needs an explicit inflation convention. |
+| 45 | `real_wage_growth` | `ABS WPI` + inflation concept | `wpi_minus_headline_cpi` | `S` | Also clearly derived. |
+
+## Concepts Requiring Extra Catalogue Work Now
+
+### Already Declared, But Still Unpopulated
+
+- `ABS LF` — `employment`, `unemployment_rate`, `participation_rate`
+- `ABS SLCI` — all household-type variants
+- `ABS ITGS` — `exports`, `imports`, `trade_balance`
+- `ABS BOP` — `current_account`, `capital_account`, `financial_account`
+- `ABS PPI` — `producer`, `export`, `import`
+- `RBA g1` — `weighted_median`
+- `RBA d1` — `credit`, `money`
+- `RBA d2` — `housing`, `business`, `household`
+- `RBA f6` — `owner_occupier`, `investor`
+- `RBA f7` — `small_business`, `large_business`
+- `RBA g3` — `consumer`, `market`, `union`
+- `RBA i1` — `trade`, `current_account`
+
+### Existing Entry, But Default Series Choice Still Needs To Be Made
+
+- `ABS WPI`
+- `ABS JV`
+- `ABS LF_UNDER`
+- `ABS LF_HOURS`
+- `ABS ERP_Q`
+- `ABS HSI_M`
+- `ABS CAPEX`
+- `ABS ANA_EXP`
+- `ABS QBIS`
+- `RBA h4`
+- `RBA f4.1`
+- `RBA f16`
+- `RBA f11`
+
+### Replacement or New Audited Entry Required
+
+- `dwelling_approvals`
+- `dwelling_prices`
+- `retail_trade`
+
+## Recommended Tranches
+
+### Tranche A
+
+Ranks `1–12`
+
+This is the best immediate semantic expansion tranche. It materially improves the server for mainstream macro, labour, inflation, credit, rates, and FX use without any provider work.
+
+### Tranche B
+
+Ranks `13–24`
+
+This tranche rounds out labour slack, spending, population, and external-sector use cases.
+
+### Tranche C
+
+Ranks `25–38`
+
+This tranche adds useful but slightly more niche concepts and concepts with more default-selection ambiguity.
+
+### Tranche D
+
+Ranks `39–45`
+
+This tranche should come last because it either needs catalogue replacement work or moves beyond the current thin resolver design.
+
+## Design Guidance
+
+- keep the semantic layer source-aware and conservative
+- prefer one documented default series per concept
+- use variants only where the distinction is already legible in the catalogue
+- avoid broad computed concepts before the source-native backlog is largely complete

--- a/docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-19-semantic-layer-expansion-design.md
@@ -144,3 +144,34 @@ This tranche should come last because it either needs catalogue replacement work
 - prefer one documented default series per concept
 - use variants only where the distinction is already legible in the catalogue
 - avoid broad computed concepts before the source-native backlog is largely complete
+
+## Implementation Notes (v0.11.0, Tranches A + B)
+
+Locked decisions recorded at implementation time so future reviewers
+can see why the defaults look the way they do:
+
+- **Bond-yield tenors resolve to `f17`, not `f16`.** `f17` (zero-coupon
+  yields) is the modelling-friendly series and avoids the coupon-driven
+  distortions in `f16`. Series IDs: `FZCY0300D` (3y), `FZCY1000D` (10y).
+- **`housing_credit` returns two SA series, not an aggregate.** The
+  default resolves `d2` to `DLCACOHS` (owner-occupier) and `DLCACIHS`
+  (investor). Clients that want a total can sum them; we deliberately
+  do not derive an aggregate to keep provenance clean.
+- **`business_credit` uses broad SA `DLCACBS`**, not the narrower
+  non-financial business series, because the broad aggregate is the
+  headline analysts reach for.
+- **`producer_price_inflation` uses `PPI_FD`**, not the input-stage
+  `PPI`, so the default matches the commonly reported final-demand
+  headline.
+- **`household_spending` uses `HSI_M` SA current-price totals.** The
+  chain-volume Australia-total series is not cleanly exposed in
+  `HSI_M`, so the current-price SA total is the least-surprising
+  default.
+- **`commodity_prices` uses the SDR index (`GRCPAISDR`)**, not the
+  AUD-denominated variant, so AUD moves are not baked into the default.
+- **`underemployment_rate` composes via structure id `DS_LF_UNDER`.**
+  The dataflow id is `LF_UNDER` but the live SDMX DataStructure is
+  exposed as `DS_LF_UNDER`; a new `resolve_abs_structure_id()` helper
+  and an optional `structure_id` field on ABS catalogue entries route
+  the structure fetch to the correct id without changing the dataflow
+  id used for data requests.

--- a/docs/superpowers/specs/2026-04-19-v1-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-19-v1-roadmap-design.md
@@ -1,0 +1,190 @@
+# Ausecon v1.0.0 Roadmap Design
+
+**Goal:** Define the shortest credible path from the current early release to a stable `v1.0.0` for `ausecon-mcp-server`.
+
+**Decision:** Treat `v1.0.0` as a correctness, contract, and usability milestone for the existing ABS + RBA server. Do not broaden the source boundary to Treasury, ASX, or APRA before `v1.0.0`.
+
+## Current Baseline
+
+The server already has a coherent core:
+
+- a thin FastMCP surface over source-specific providers
+- curated ABS and RBA catalogues
+- normalised response payloads
+- resources and prompt templates
+- retry, cache, and logging support
+- unit tests and live integration checks
+
+The main remaining weakness is not raw feature count. It is catalogue correctness and semantic coverage.
+
+The April 2026 audit established that several ABS entries were ceased or mislabelled and that multiple RBA entries pointed at live upstream tables whose content no longer matched the catalogue description. That class of defect is more severe than ordinary breadth gaps because the server can return plausible-looking but materially wrong data.
+
+## Scope Decision
+
+### In Scope for v1.0.0
+
+- ABS and RBA only
+- local stdio MCP transport
+- stable read-only discovery and retrieval workflows
+- expanded but disciplined semantic shortcut layer
+- explicit contract documentation for response shapes
+
+### Out of Scope for v1.0.0
+
+- Treasury as a primary statistical source
+- ASX market-data integration
+- APRA integration
+- non-time-series RBA distribution tables that require a different response model
+- broad analytical transforms beyond a very small number of obvious derived concepts
+- hosted HTTP or streamable transport as a release gate
+
+## Why Treasury, ASX, and APRA Are Not v1.0.0 Work
+
+### Treasury
+
+Treasury is not the right primary upstream for this server's current purpose. For official Australian macroeconomic and financial statistics, Treasury generally points users back to ABS and RBA rather than acting as the system of record for the statistical series themselves. Adding Treasury before `v1.0.0` would broaden the product without solving the core correctness and contract risks in the existing server.
+
+### ASX
+
+ASX is a poor fit for this release boundary. The server is currently positioned as a curated public-statistics MCP server, not a market-data product. ASX would introduce a different product category, a different user expectation set, and likely more commercial-data complications than the current public ABS and RBA surfaces.
+
+### APRA
+
+APRA is the only realistic next source after `v1.0.0`. It fits the macro-financial mission better than Treasury or ASX, but it is still a proper third-source expansion, not a small additive change. It should land only after the ABS + RBA contract is stable.
+
+## Product Positioning for v1.0.0
+
+`ausecon-mcp-server` should be described at `v1.0.0` as:
+
+> A stable, source-aware MCP server for official Australian macroeconomic and financial data from the ABS and RBA, with curated discovery, provenance-rich retrieval, and a practical economist-facing semantic layer.
+
+That is narrow enough to be credible and broad enough to be useful.
+
+## Release Sequence
+
+### v0.10.0 — Correctness and Audit Governance
+
+This is the highest-priority tranche.
+
+- fix all known wrong RBA catalogue mappings by relabelling or replacing entries so the catalogue matches the live upstream table
+- mark ceased ABS entries correctly and remove them from ordinary discovery paths
+- complete the `LCI` to `SLCI` correction and keep naming, aliases, tags, and prompts consistent
+- add audit metadata consistently to catalogue entries
+- build a repeatable catalogue audit script for ABS and RBA
+- wire audit checks into the nightly live verification workflow
+
+**Exit condition:** no known catalogue entry returns materially different content from its stated meaning.
+
+### v0.11.0 — Semantic Layer and Discovery Expansion
+
+This is the next highest-value tranche because it improves user utility without broadening the source boundary.
+
+- expand `get_economic_series` beyond the current four shortcuts
+- prioritise labour, wages, credit, external sector, and yield concepts
+- add `last_n` support to `get_economic_series`
+- add a filtered `list_catalogue` tool or equivalent discovery primitive for source, category, and tag browsing
+- align prompts and resources with the expanded semantic layer
+
+**Exit condition:** the server has a practical first-tier semantic surface for common macroeconomic workflows.
+
+### v0.12.0 — Remaining In-Scope Breadth
+
+This tranche fills obvious, still-missing ABS and RBA coverage that stays inside the current time-series contract.
+
+- add missing or replacement catalogue entries where the current concept is important but the underlying source changed
+- finish only those catalogue additions that materially support the semantic backlog
+- avoid long-tail table additions that do not improve the main analyst workflows
+
+**Exit condition:** no obvious, high-demand ABS or RBA concept is missing because of a small catalogue gap.
+
+### v0.13.0 — Contract Freeze
+
+This tranche turns the current informal response model into an explicit compatibility promise.
+
+- write checked-in JSON Schemas for the main response payloads
+- write example payloads for the documented happy paths
+- decide whether to make one intentional response-shape cleanup before `v1.0.0`
+- if a breaking cleanup is made, publish a short migration note and stop changing the response contract afterwards
+
+**Exit condition:** payload structure is explicit, documented, and stable enough for downstream consumers to rely on.
+
+### v0.14.0-rc1 — Release Candidate
+
+This is the stabilisation tranche.
+
+- documentation refresh
+- architecture note
+- semantic concept reference
+- schema reference
+- release checklist and migration note
+- no contract changes during the RC window
+
+**Exit condition:** one clean release-candidate cycle with no contract churn and no newly discovered correctness regressions.
+
+### v1.0.0
+
+Tag the release only after:
+
+- unit tests are green
+- live integration checks are green
+- audit automation is green
+- no known wrong catalogue mappings remain
+- the semantic layer covers the agreed first-tier concept set
+- schemas and docs reflect actual behaviour
+
+## Semantic Layer Direction
+
+The semantic layer should remain thin and source-aware.
+
+That means:
+
+- prefer source-native concepts over arbitrary computed statistics
+- map each concept to one documented default series
+- support variants where the catalogue already encodes defensible distinctions
+- avoid turning the server into a general transformation engine before `v1.0.0`
+
+The separate semantic-layer backlog document holds the ranked concept list and tranche ordering.
+
+## Engineering Guidance
+
+### Keep for v1.0.0
+
+- thin MCP server
+- source-specific providers
+- static curated catalogues
+- explicit validation at the tool boundary
+- provenance-rich JSON payloads
+
+### Improve Before v1.0.0
+
+- catalogue auditability
+- semantic shortcut coverage
+- contract documentation
+- discovery ergonomics
+- test coverage around catalogue correctness and semantic defaults
+
+### Defer Until After v1.0.0
+
+- APRA provider work
+- HTTP or streamable server transport
+- extensive provider inheritance refactors
+- larger derived-series framework
+
+## Release Gates
+
+`v1.0.0` should not ship until all of the following are true:
+
+1. The catalogue is audit-backed and known-bad mappings are fixed.
+2. Ceased entries are handled explicitly and do not pollute ordinary discovery.
+3. `get_economic_series` covers the agreed first-tier concepts.
+4. Response schemas are checked in and match runtime behaviour.
+5. The release candidate passes one clean stabilisation cycle with no contract changes.
+
+## Post-v1 Candidates
+
+These are good `v1.1+` candidates:
+
+- APRA ADI statistics as the first third source
+- HTTP or streamable transport for hosted deployments
+- carefully chosen derived concepts such as `yield_curve_slope`, `real_cash_rate`, and `gdp_per_capita`
+- non-time-series statistical tables that require a second response model

--- a/integration_tests/test_semantic_live.py
+++ b/integration_tests/test_semantic_live.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from ausecon_mcp.server import AuseconService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _call(concept: str) -> dict:
+    service = AuseconService()
+    return await service.get_economic_series(concept, last_n=4)
+
+
+# Tranche A live coverage
+
+
+async def test_live_semantic_unemployment_rate() -> None:
+    result = await _call("unemployment_rate")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "LF"
+    assert result["observations"], "expected observations for unemployment_rate"
+
+
+async def test_live_semantic_wage_growth() -> None:
+    result = await _call("wage_growth")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "WPI"
+    assert result["observations"]
+
+
+async def test_live_semantic_monthly_inflation() -> None:
+    result = await _call("monthly_inflation")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "g4"
+    series_ids = {s["series_id"] for s in result["series"]}
+    assert "GCPIAGSAMP" in series_ids
+
+
+async def test_live_semantic_government_bond_yield_10y() -> None:
+    result = await _call("government_bond_yield_10y")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "f17"
+    series_ids = {s["series_id"] for s in result["series"]}
+    assert "FZCY1000D" in series_ids
+
+
+async def test_live_semantic_housing_credit() -> None:
+    result = await _call("housing_credit")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "d2"
+    series_ids = {s["series_id"] for s in result["series"]}
+    assert {"DLCACOHS", "DLCACIHS"} <= series_ids
+
+
+# Tranche B live coverage
+
+
+async def test_live_semantic_current_account_balance() -> None:
+    result = await _call("current_account_balance")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "BOP"
+    assert result["observations"]
+
+
+async def test_live_semantic_underemployment_rate() -> None:
+    result = await _call("underemployment_rate")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "LF_UNDER"
+    assert result["observations"]
+
+
+async def test_live_semantic_mortgage_rate() -> None:
+    result = await _call("mortgage_rate")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "f6"
+    series_ids = {s["series_id"] for s in result["series"]}
+    assert "FLRHOOVA" in series_ids
+
+
+async def test_live_semantic_population() -> None:
+    result = await _call("population")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "ERP_Q"
+    assert result["observations"]
+
+
+async def test_live_semantic_commodity_prices() -> None:
+    result = await _call("commodity_prices")
+
+    assert result["metadata"]["source"] == "rba"
+    assert result["metadata"]["dataset_id"] == "i2"
+    series_ids = {s["series_id"] for s in result["series"]}
+    assert "GRCPAISDR" in series_ids

--- a/src/ausecon_mcp/catalogue/abs.py
+++ b/src/ausecon_mcp/catalogue/abs.py
@@ -195,7 +195,13 @@ ABS_CATALOGUE = {
         ],
         "frequencies": ["Q"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "headline_wpi",
+                "aliases": ["headline", "total hourly rates"],
+                "abs_key": "3.THRPEB.7.TOT.20.AUS.Q",
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/WPI/latest",
@@ -310,16 +316,20 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [
-            {"name": "employment", "aliases": ["employed persons"], "abs_key": None},
+            {
+                "name": "employment",
+                "aliases": ["employed persons"],
+                "abs_key": "M3.3.1599.20.AUS.M",
+            },
             {
                 "name": "unemployment_rate",
                 "aliases": ["unemployment", "jobless rate"],
-                "abs_key": None,
+                "abs_key": "M13.3.1599.20.AUS.M",
             },
             {
                 "name": "participation_rate",
                 "aliases": ["participation"],
-                "abs_key": None,
+                "abs_key": "M12.3.1599.20.AUS.M",
             },
         ],
         "audit": {
@@ -974,7 +984,11 @@ ABS_CATALOGUE = {
         "variants": [
             {"name": "exports", "aliases": [], "abs_key": None},
             {"name": "imports", "aliases": [], "abs_key": None},
-            {"name": "trade_balance", "aliases": ["net exports"], "abs_key": None},
+            {
+                "name": "trade_balance",
+                "aliases": ["net exports"],
+                "abs_key": "M1.170.20.AUS.M",
+            },
         ],
         "audit": {
             "last_audited": "2026-04-18",

--- a/src/ausecon_mcp/catalogue/abs.py
+++ b/src/ausecon_mcp/catalogue/abs.py
@@ -117,7 +117,13 @@ ABS_CATALOGUE = {
         ],
         "frequencies": ["Q"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "producer",
+                "aliases": ["producer prices", "ppi final demand total"],
+                "abs_key": "3.TOT.TOT.TOTXE.Q",
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/PPI_FD/latest",
@@ -357,7 +363,13 @@ ABS_CATALOGUE = {
         ],
         "frequencies": ["M"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "headline_hours",
+                "aliases": ["aggregate hours", "hours worked"],
+                "abs_key": "M18.3.1599.TOT.20.AUS.M",
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LF_HOURS/latest",
@@ -384,7 +396,13 @@ ABS_CATALOGUE = {
         ],
         "frequencies": ["M"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "headline_underemployment",
+                "aliases": ["underemployment rate", "underemployment"],
+                "abs_key": "M23.3.1599.20.AUS.M",
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/LF_UNDER/latest",
@@ -477,7 +495,13 @@ ABS_CATALOGUE = {
         ],
         "frequencies": ["Q"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "headline_vacancies",
+                "aliases": ["total vacancies", "job vacancies"],
+                "abs_key": "M1.7.TOT.20.AUS.Q",
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/JV/latest",
@@ -775,7 +799,13 @@ ABS_CATALOGUE = {
         ],
         "frequencies": ["M"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "headline_spending",
+                "aliases": ["total spending", "household spending headline"],
+                "abs_key": "7.TOT.CUR.20.AUS.M",
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/HSI_M/latest",
@@ -1069,7 +1099,7 @@ ABS_CATALOGUE = {
         "frequencies": ["Q"],
         "geographies": ["national"],
         "variants": [
-            {"name": "current_account", "aliases": [], "abs_key": None},
+            {"name": "current_account", "aliases": [], "abs_key": "1.100.20.Q"},
             {"name": "capital_account", "aliases": [], "abs_key": None},
             {"name": "financial_account", "aliases": [], "abs_key": None},
         ],
@@ -1271,7 +1301,13 @@ ABS_CATALOGUE = {
         ],
         "frequencies": ["Q"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "headline_population",
+                "aliases": ["resident population", "erp headline"],
+                "abs_key": "1.3.TOT.AUS.Q",
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/ERP_Q/latest",

--- a/src/ausecon_mcp/catalogue/abs.py
+++ b/src/ausecon_mcp/catalogue/abs.py
@@ -366,6 +366,7 @@ ABS_CATALOGUE = {
     },
     "LF_UNDER": {
         "id": "LF_UNDER",
+        "structure_id": "DS_LF_UNDER",
         "source": "abs",
         "name": "Labour Force - Underutilisation",
         "description": "Underemployment, underutilisation, and slack labour market indicators.",

--- a/src/ausecon_mcp/catalogue/rba.py
+++ b/src/ausecon_mcp/catalogue/rba.py
@@ -565,7 +565,11 @@ RBA_CATALOGUE = {
                 "aliases": ["housing credit"],
                 "rba_series_ids": ["DLCACOHS", "DLCACIHS"],
             },
-            {"name": "business", "aliases": ["business credit"], "rba_series_ids": None},
+            {
+                "name": "business",
+                "aliases": ["business credit"],
+                "rba_series_ids": ["DLCACBS"],
+            },
             {"name": "household", "aliases": ["household credit"], "rba_series_ids": None},
         ],
         "audit": {
@@ -1047,6 +1051,11 @@ RBA_CATALOGUE = {
         "geographies": ["national"],
         "variants": [
             {"name": "owner_occupier", "aliases": ["owner-occupier"], "rba_series_ids": None},
+            {
+                "name": "owner_occupier_variable",
+                "aliases": ["owner-occupier variable rate", "variable mortgage rate"],
+                "rba_series_ids": ["FLRHOOVA"],
+            },
             {"name": "investor", "aliases": ["investment"], "rba_series_ids": None},
         ],
         "audit": {
@@ -1076,6 +1085,11 @@ RBA_CATALOGUE = {
         "geographies": ["national"],
         "variants": [
             {"name": "small_business", "aliases": ["sme rates"], "rba_series_ids": None},
+            {
+                "name": "small_business_indicator",
+                "aliases": ["small business indicator rate"],
+                "rba_series_ids": ["FLRBFOSBT"],
+            },
             {"name": "large_business", "aliases": [], "rba_series_ids": None},
         ],
         "audit": {
@@ -1408,7 +1422,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M", "Q"],
         "geographies": ["national"],
         "variants": [
-            {"name": "consumer", "aliases": ["consumer expectations"], "rba_series_ids": None},
+            {
+                "name": "consumer",
+                "aliases": ["consumer expectations"],
+                "rba_series_ids": ["GCONEXP"],
+            },
             {"name": "market", "aliases": ["market expectations"], "rba_series_ids": None},
             {"name": "union", "aliases": [], "rba_series_ids": None},
         ],
@@ -1669,7 +1687,13 @@ RBA_CATALOGUE = {
         ],
         "frequencies": ["M"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "rba_commodity_index",
+                "aliases": ["rba commodity price index", "all items sdr"],
+                "rba_series_ids": ["GRCPAISDR"],
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/i2-data.csv",

--- a/src/ausecon_mcp/catalogue/rba.py
+++ b/src/ausecon_mcp/catalogue/rba.py
@@ -560,7 +560,11 @@ RBA_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [
-            {"name": "housing", "aliases": ["housing credit"], "rba_series_ids": None},
+            {
+                "name": "housing",
+                "aliases": ["housing credit"],
+                "rba_series_ids": ["DLCACOHS", "DLCACIHS"],
+            },
             {"name": "business", "aliases": ["business credit"], "rba_series_ids": None},
             {"name": "household", "aliases": ["household credit"], "rba_series_ids": None},
         ],
@@ -1133,7 +1137,18 @@ RBA_CATALOGUE = {
         ],
         "frequencies": ["D"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "aud_usd",
+                "aliases": ["aud usd", "usd", "aud-usd"],
+                "rba_series_ids": ["FXRUSD"],
+            },
+            {
+                "name": "twi",
+                "aliases": ["trade weighted index", "trade-weighted index"],
+                "rba_series_ids": ["FXRTWI"],
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f11-data.csv",
@@ -1285,7 +1300,18 @@ RBA_CATALOGUE = {
         ],
         "frequencies": ["D"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "ags_3y",
+                "aliases": ["3 year yield", "3y"],
+                "rba_series_ids": ["FZCY300D"],
+            },
+            {
+                "name": "ags_10y",
+                "aliases": ["10 year yield", "10y"],
+                "rba_series_ids": ["FZCY1000D"],
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/f17-yields.csv",
@@ -1327,7 +1353,7 @@ RBA_CATALOGUE = {
             {
                 "name": "weighted_median",
                 "aliases": ["weighted median inflation"],
-                "rba_series_ids": None,
+                "rba_series_ids": ["GCPIOCPMWMYP"],
             },
         ],
         "audit": {
@@ -1416,7 +1442,13 @@ RBA_CATALOGUE = {
         ],
         "frequencies": ["M"],
         "geographies": ["national"],
-        "variants": [],
+        "variants": [
+            {
+                "name": "headline_monthly",
+                "aliases": ["monthly headline", "monthly cpi"],
+                "rba_series_ids": ["GCPIAGSAMP"],
+            },
+        ],
         "audit": {
             "last_audited": "2026-04-18",
             "upstream_url": "https://www.rba.gov.au/statistics/tables/csv/g4-data.csv",

--- a/src/ausecon_mcp/catalogue/resolver.py
+++ b/src/ausecon_mcp/catalogue/resolver.py
@@ -47,6 +47,21 @@ def resolve_abs_dataflow_id(dataflow_id: str) -> str:
     return entry.get("upstream_id", dataflow_id)
 
 
+def resolve_abs_structure_id(dataflow_id: str) -> str:
+    """Map a catalogue key to its upstream ABS SDMX DataStructure ID.
+
+    Some ABS dataflows expose their DataStructure under a different ID than the
+    dataflow itself (for example, dataflow ``LF_UNDER`` has structure
+    ``DS_LF_UNDER``). Catalogue entries may declare an optional ``structure_id``
+    to capture this. Falls back to the dataflow id so unknown keys and entries
+    without ``structure_id`` pass through unchanged.
+    """
+    entry = ABS_CATALOGUE.get(dataflow_id)
+    if entry is None:
+        return dataflow_id
+    return entry.get("structure_id", dataflow_id)
+
+
 def resolve_rba_csv_path(table_id: str) -> str:
     """Map a catalogue key to its upstream RBA CSV filename.
 
@@ -289,7 +304,7 @@ async def _resolve_abs_key(
             f"Resolving {entry['id']!r} with variant/frequency/geography requires the "
             "ABS dataset structure; no abs_structure_fetcher was provided."
         )
-    structure = await abs_structure_fetcher(entry["id"])
+    structure = await abs_structure_fetcher(resolve_abs_structure_id(entry["id"]))
 
     fragment: dict[str, str] = {}
     if variant_key is not None:

--- a/src/ausecon_mcp/catalogue/resolver.py
+++ b/src/ausecon_mcp/catalogue/resolver.py
@@ -99,6 +99,35 @@ CURATED_SHORTCUTS: dict[str, dict[str, Any]] = {
     "government_bond_yield_3y": {"source": "rba", "dataset_id": "f17", "variant": "ags_3y"},
     "government_bond_yield_10y": {"source": "rba", "dataset_id": "f17", "variant": "ags_10y"},
     "housing_credit": {"source": "rba", "dataset_id": "d2", "variant": "housing"},
+    # Tranche B
+    "business_credit": {"source": "rba", "dataset_id": "d2", "variant": "business"},
+    "current_account_balance": {
+        "source": "abs",
+        "dataset_id": "BOP",
+        "variant": "current_account",
+    },
+    "underemployment_rate": {
+        "source": "abs",
+        "dataset_id": "LF_UNDER",
+        "variant": "headline_underemployment",
+    },
+    "hours_worked": {"source": "abs", "dataset_id": "LF_HOURS", "variant": "headline_hours"},
+    "job_vacancies": {"source": "abs", "dataset_id": "JV", "variant": "headline_vacancies"},
+    "mortgage_rate": {"source": "rba", "dataset_id": "f6", "variant": "owner_occupier_variable"},
+    "business_lending_rate": {
+        "source": "rba",
+        "dataset_id": "f7",
+        "variant": "small_business_indicator",
+    },
+    "population": {"source": "abs", "dataset_id": "ERP_Q", "variant": "headline_population"},
+    "inflation_expectations": {"source": "rba", "dataset_id": "g3", "variant": "consumer"},
+    "producer_price_inflation": {"source": "abs", "dataset_id": "PPI_FD", "variant": "producer"},
+    "household_spending": {
+        "source": "abs",
+        "dataset_id": "HSI_M",
+        "variant": "headline_spending",
+    },
+    "commodity_prices": {"source": "rba", "dataset_id": "i2", "variant": "rba_commodity_index"},
 }
 
 

--- a/src/ausecon_mcp/catalogue/resolver.py
+++ b/src/ausecon_mcp/catalogue/resolver.py
@@ -67,6 +67,23 @@ CURATED_SHORTCUTS: dict[str, dict[str, Any]] = {
     "headline_cpi": {"source": "abs", "dataset_id": "CPI", "variant": "headline"},
     "trimmed_mean_inflation": {"source": "rba", "dataset_id": "g1", "variant": "trimmed_mean"},
     "gdp_growth": {"source": "abs", "dataset_id": "ANA_AGG", "variant": "gdp_growth"},
+    # Tranche A
+    "employment": {"source": "abs", "dataset_id": "LF", "variant": "employment"},
+    "unemployment_rate": {"source": "abs", "dataset_id": "LF", "variant": "unemployment_rate"},
+    "participation_rate": {"source": "abs", "dataset_id": "LF", "variant": "participation_rate"},
+    "wage_growth": {"source": "abs", "dataset_id": "WPI", "variant": "headline_wpi"},
+    "trade_balance": {"source": "abs", "dataset_id": "ITGS", "variant": "trade_balance"},
+    "weighted_median_inflation": {
+        "source": "rba",
+        "dataset_id": "g1",
+        "variant": "weighted_median",
+    },
+    "monthly_inflation": {"source": "rba", "dataset_id": "g4", "variant": "headline_monthly"},
+    "aud_usd": {"source": "rba", "dataset_id": "f11", "variant": "aud_usd"},
+    "trade_weighted_index": {"source": "rba", "dataset_id": "f11", "variant": "twi"},
+    "government_bond_yield_3y": {"source": "rba", "dataset_id": "f17", "variant": "ags_3y"},
+    "government_bond_yield_10y": {"source": "rba", "dataset_id": "f17", "variant": "ags_10y"},
+    "housing_credit": {"source": "rba", "dataset_id": "d2", "variant": "housing"},
 }
 
 

--- a/src/ausecon_mcp/catalogue/search.py
+++ b/src/ausecon_mcp/catalogue/search.py
@@ -53,6 +53,46 @@ def search_catalogue(query: str, source: str | None = None) -> list[dict]:
     return sorted(results, key=lambda item: (-item["score"], item["source"], item["id"]))
 
 
+def list_catalogue(
+    source: str | None = None,
+    category: str | None = None,
+    tag: str | None = None,
+    include_ceased: bool = False,
+    include_discontinued: bool = False,
+) -> list[dict]:
+    """Return unranked catalogue rows, optionally filtered by source, category, or tag.
+
+    Complements ``search_catalogue`` (ranked keyword search) by exposing the full
+    catalogue with lightweight filtering. Excludes ceased/discontinued entries by
+    default; callers opt in via the ``include_*`` toggles.
+    """
+    tag_normalised = tag.lower() if tag else None
+    results: list[dict] = []
+    for collection_source, collection in _iter_collections(source):
+        for entry in collection.values():
+            if entry.get("ceased", False) and not include_ceased:
+                continue
+            if entry.get("discontinued", False) and not include_discontinued:
+                continue
+            if category is not None and entry.get("category") != category:
+                continue
+            if tag_normalised is not None:
+                entry_tags = [t.lower() for t in entry.get("tags", [])]
+                if tag_normalised not in entry_tags:
+                    continue
+            results.append(
+                {
+                    "id": entry["id"],
+                    "source": collection_source,
+                    "name": entry["name"],
+                    "category": entry.get("category"),
+                    "frequency": entry.get("frequency"),
+                    "tags": list(entry.get("tags", [])),
+                }
+            )
+    return sorted(results, key=lambda item: (item["source"], item["id"]))
+
+
 def _iter_collections(source: str | None) -> Iterable[tuple[str, dict]]:
     if source in (None, "abs"):
         yield "abs", ABS_CATALOGUE

--- a/src/ausecon_mcp/prompts.py
+++ b/src/ausecon_mcp/prompts.py
@@ -149,6 +149,60 @@ def register_prompts(mcp: FastMCP) -> None:
         )
 
     @mcp.prompt(
+        name="labour_slack_snapshot",
+        description=(
+            "Summarise Australian labour-market slack using the unemployment and "
+            "underemployment rates over a recent window."
+        ),
+    )
+    def labour_slack_snapshot(last_n: int = 12) -> str:
+        return (
+            "The user wants a clear read on Australian labour-market slack over "
+            f"the last {last_n} monthly observations.\n"
+            "\n"
+            "Do the following using tools from this MCP server:\n"
+            f'1. Call `get_economic_series` with concept="unemployment_rate", last_n={last_n}.\n'
+            f'2. Call `get_economic_series` with concept="underemployment_rate", '
+            f"last_n={last_n}.\n"
+            "\n"
+            "Then write 3-5 sentences covering:\n"
+            "- the latest unemployment rate and its observation date,\n"
+            "- the latest underemployment rate and its observation date,\n"
+            "- the combined underutilisation signal and whether slack is "
+            "tightening or loosening,\n"
+            "- one sentence of context on what that implies for wages pressure.\n"
+            "\n"
+            "Use only the values returned by the tools."
+        )
+
+    @mcp.prompt(
+        name="yield_curve_snapshot",
+        description=(
+            "Compare the 3-year and 10-year Australian Government Security yields "
+            "over a recent window to describe the curve shape."
+        ),
+    )
+    def yield_curve_snapshot(last_n: int = 60) -> str:
+        return (
+            f"Build a snapshot of the Australian Government Security yield curve "
+            f"using the last {last_n} daily observations.\n"
+            "\n"
+            "Do the following using tools from this MCP server:\n"
+            f'1. Call `get_economic_series` with concept="government_bond_yield_3y", '
+            f"last_n={last_n}.\n"
+            f'2. Call `get_economic_series` with concept="government_bond_yield_10y", '
+            f"last_n={last_n}.\n"
+            "\n"
+            "Then write 3-5 sentences covering:\n"
+            "- the latest 3y and 10y yields and their observation date,\n"
+            "- the 10y-minus-3y spread and whether the curve is positively "
+            "sloped, flat, or inverted,\n"
+            "- how the curve has shifted over the window shown.\n"
+            "\n"
+            "Report only the values the tools return."
+        )
+
+    @mcp.prompt(
         name="discover_dataset",
         description=(
             "Find and recommend the best ABS datasets or RBA tables for a given economic topic."

--- a/src/ausecon_mcp/resources.py
+++ b/src/ausecon_mcp/resources.py
@@ -5,6 +5,7 @@ from fastmcp.exceptions import ResourceError
 
 from ausecon_mcp.catalogue.abs import ABS_CATALOGUE
 from ausecon_mcp.catalogue.rba import RBA_CATALOGUE
+from ausecon_mcp.catalogue.resolver import CURATED_SHORTCUTS
 
 _CATALOGUE_SUMMARY_FIELDS = (
     "id",
@@ -37,6 +38,35 @@ def register_resources(mcp: FastMCP) -> None:
             _summarise(entry)
             for entry in list(ABS_CATALOGUE.values()) + list(RBA_CATALOGUE.values())
         ]
+
+    @mcp.resource(
+        "ausecon://concepts",
+        name="Ausecon semantic concepts",
+        description=(
+            "Every curated semantic shortcut accepted by get_economic_series, with its "
+            "resolved target dataset, variant, supported frequencies, and geographies."
+        ),
+        mime_type="application/json",
+        annotations={"readOnlyHint": True},
+    )
+    def concepts_index() -> list[dict]:
+        rows: list[dict] = []
+        for concept, shortcut in CURATED_SHORTCUTS.items():
+            source = shortcut["source"]
+            dataset_id = shortcut["dataset_id"]
+            catalogue = ABS_CATALOGUE if source == "abs" else RBA_CATALOGUE
+            entry = catalogue.get(dataset_id, {})
+            rows.append(
+                {
+                    "concept": concept,
+                    "source": source,
+                    "dataset_id": dataset_id,
+                    "variant": shortcut.get("variant"),
+                    "frequencies": list(entry.get("frequencies", [])),
+                    "geographies": list(entry.get("geographies", [])),
+                }
+            )
+        return rows
 
     @mcp.resource(
         "ausecon://abs/{dataflow_id}",

--- a/src/ausecon_mcp/server.py
+++ b/src/ausecon_mcp/server.py
@@ -11,6 +11,8 @@ from ausecon_mcp.catalogue.resolver import (
 )
 from ausecon_mcp.catalogue.search import (
     list_catalogue as _list_catalogue,
+)
+from ausecon_mcp.catalogue.search import (
     search_catalogue,
 )
 from ausecon_mcp.logging import configure_logging, get_logger

--- a/src/ausecon_mcp/server.py
+++ b/src/ausecon_mcp/server.py
@@ -122,8 +122,10 @@ class AuseconService:
         frequency: str | None = None,
         start: str | None = None,
         end: str | None = None,
+        last_n: int | None = None,
     ) -> dict:
         validated_concept = require_non_empty("concept", concept)
+        validated_last_n = validate_positive_int("last_n", last_n)
         resolved = await resolve(
             validated_concept,
             variant=variant,
@@ -144,7 +146,7 @@ class AuseconService:
                 series_ids=resolved.rba_series_ids,
                 start_date=validated_start,
                 end_date=validated_end,
-                last_n=None,
+                last_n=validated_last_n,
             )
 
         validated_start, validated_end = validate_abs_period_range(
@@ -158,6 +160,7 @@ class AuseconService:
             key=resolved.abs_key or "all",
             start_period=validated_start,
             end_period=validated_end,
+            last_n=validated_last_n,
         )
 
 
@@ -236,9 +239,11 @@ def build_server(service: AuseconService | None = None) -> FastMCP:
         frequency: str | None = None,
         start: str | None = None,
         end: str | None = None,
+        last_n: int | None = None,
     ) -> dict:
         """Resolve an economic concept to an ABS or RBA retrieval, optionally narrowing by
-        variant, geography, and frequency."""
+        variant, geography, and frequency. Use ``last_n`` to cap observations to the most
+        recent N."""
         return await app_service.get_economic_series(
             concept=concept,
             variant=variant,
@@ -246,6 +251,7 @@ def build_server(service: AuseconService | None = None) -> FastMCP:
             frequency=frequency,
             start=start,
             end=end,
+            last_n=last_n,
         )
 
     register_resources(mcp)

--- a/src/ausecon_mcp/server.py
+++ b/src/ausecon_mcp/server.py
@@ -9,7 +9,10 @@ from ausecon_mcp.catalogue.resolver import (
     resolve_abs_dataflow_id,
     resolve_rba_csv_path,
 )
-from ausecon_mcp.catalogue.search import search_catalogue
+from ausecon_mcp.catalogue.search import (
+    list_catalogue as _list_catalogue,
+    search_catalogue,
+)
 from ausecon_mcp.logging import configure_logging, get_logger
 from ausecon_mcp.prompts import register_prompts
 from ausecon_mcp.providers.abs import ABSProvider
@@ -41,6 +44,23 @@ class AuseconService:
         validated_query = validate_search_query(query)
         validated_source = validate_source(source)
         return search_catalogue(validated_query, source=validated_source)
+
+    async def list_catalogue(
+        self,
+        source: str | None = None,
+        category: str | None = None,
+        tag: str | None = None,
+        include_ceased: bool = False,
+        include_discontinued: bool = False,
+    ) -> list[dict]:
+        validated_source = validate_source(source)
+        return _list_catalogue(
+            source=validated_source,
+            category=category,
+            tag=tag,
+            include_ceased=include_ceased,
+            include_discontinued=include_discontinued,
+        )
 
     async def get_abs_dataset_structure(self, dataflow_id: str) -> dict:
         validated_dataflow_id = require_non_empty("dataflow_id", dataflow_id)
@@ -178,6 +198,24 @@ def build_server(service: AuseconService | None = None) -> FastMCP:
     async def search_datasets(query: str, source: str | None = None) -> list[dict]:
         """Search curated ABS and RBA economic datasets."""
         return await app_service.search_datasets(query=query, source=source)
+
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
+    async def list_catalogue(
+        source: str | None = None,
+        category: str | None = None,
+        tag: str | None = None,
+        include_ceased: bool = False,
+        include_discontinued: bool = False,
+    ) -> list[dict]:
+        """List curated ABS and RBA catalogue entries, optionally filtered by source,
+        category, or tag. Unranked complement to ``search_datasets``."""
+        return await app_service.list_catalogue(
+            source=source,
+            category=category,
+            tag=tag,
+            include_ceased=include_ceased,
+            include_discontinued=include_discontinued,
+        )
 
     @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
     async def get_abs_dataset_structure(dataflow_id: str) -> dict:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -25,6 +25,8 @@ async def test_prompts_are_listed() -> None:
         "macro_snapshot",
         "living_costs_vs_cpi",
         "construction_pipeline",
+        "labour_slack_snapshot",
+        "yield_curve_snapshot",
         "discover_dataset",
     } <= names
 
@@ -86,6 +88,28 @@ async def test_construction_pipeline_references_all_series() -> None:
     for dataflow in ("CWD", "EWD", "BUILDING_ACTIVITY"):
         assert dataflow in text
     assert "12" in text
+
+
+async def test_labour_slack_snapshot_references_both_rates() -> None:
+    mcp = build_server()
+
+    async with Client(mcp) as client:
+        text = await _get_prompt_text(client, "labour_slack_snapshot", {"last_n": 24})
+
+    assert "unemployment_rate" in text
+    assert "underemployment_rate" in text
+    assert "24" in text
+
+
+async def test_yield_curve_snapshot_references_both_tenors() -> None:
+    mcp = build_server()
+
+    async with Client(mcp) as client:
+        text = await _get_prompt_text(client, "yield_curve_snapshot", {"last_n": 90})
+
+    assert "government_bond_yield_3y" in text
+    assert "government_bond_yield_10y" in text
+    assert "90" in text
 
 
 async def test_discover_dataset_embeds_topic() -> None:

--- a/tests/test_repository_hygiene.py
+++ b/tests/test_repository_hygiene.py
@@ -75,8 +75,8 @@ def test_ci_workflow_exists_with_quality_checks_and_hygiene_guard() -> None:
 def test_readme_tracks_current_release_state() -> None:
     readme_text = README.read_text(encoding="utf-8")
     tool_row = (
-        "`get_economic_series` | Resolve a small set of high-value economic concepts to ABS or "
-        "RBA retrievals | `concept`, `variant`, `geography`, `frequency`, `start`, `end` |"
+        "`get_economic_series` | Resolve a curated economic concept to an ABS or RBA retrieval | "
+        "`concept`, `variant`, `geography`, `frequency`, `start`, `end`, `last_n` |"
     )
 
     assert "https://pypi.org/project/ausecon-mcp-server/" in readme_text

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -77,7 +77,7 @@ async def test_resolve_rba_variant_returns_populated_series_ids() -> None:
 @pytest.mark.asyncio
 async def test_resolve_rba_unpopulated_variant_raises() -> None:
     with pytest.raises(ValueError, match="rba_series_ids populated"):
-        await resolve("trimmed_mean_inflation", variant="weighted_median")
+        await resolve("g3", variant="market")
 
 
 @pytest.mark.asyncio
@@ -243,10 +243,66 @@ def test_resolve_rba_csv_path_uses_explicit_csv_path_when_declared() -> None:
         del RBA_CATALOGUE["__test__"]
 
 
-def test_curated_shortcuts_cover_v030_concepts() -> None:
+def test_curated_shortcuts_cover_v0110_tranche_a_concepts() -> None:
     assert set(CURATED_SHORTCUTS) == {
         "cash_rate_target",
         "headline_cpi",
         "trimmed_mean_inflation",
         "gdp_growth",
+        # Tranche A
+        "employment",
+        "unemployment_rate",
+        "participation_rate",
+        "wage_growth",
+        "trade_balance",
+        "weighted_median_inflation",
+        "monthly_inflation",
+        "aud_usd",
+        "trade_weighted_index",
+        "government_bond_yield_3y",
+        "government_bond_yield_10y",
+        "housing_credit",
     }
+
+
+TRANCHE_A_ABS = [
+    ("employment", "LF", "employment", "M3.3.1599.20.AUS.M"),
+    ("unemployment_rate", "LF", "unemployment_rate", "M13.3.1599.20.AUS.M"),
+    ("participation_rate", "LF", "participation_rate", "M12.3.1599.20.AUS.M"),
+    ("wage_growth", "WPI", "headline_wpi", "3.THRPEB.7.TOT.20.AUS.Q"),
+    ("trade_balance", "ITGS", "trade_balance", "M1.170.20.AUS.M"),
+]
+
+TRANCHE_A_RBA = [
+    ("weighted_median_inflation", "g1", "weighted_median", ["GCPIOCPMWMYP"]),
+    ("monthly_inflation", "g4", "headline_monthly", ["GCPIAGSAMP"]),
+    ("aud_usd", "f11", "aud_usd", ["FXRUSD"]),
+    ("trade_weighted_index", "f11", "twi", ["FXRTWI"]),
+    ("government_bond_yield_3y", "f17", "ags_3y", ["FZCY300D"]),
+    ("government_bond_yield_10y", "f17", "ags_10y", ["FZCY1000D"]),
+    ("housing_credit", "d2", "housing", ["DLCACOHS", "DLCACIHS"]),
+]
+
+
+@pytest.mark.parametrize(("concept", "dataset_id", "variant", "abs_key"), TRANCHE_A_ABS)
+@pytest.mark.asyncio
+async def test_resolve_tranche_a_abs_concepts(
+    concept: str, dataset_id: str, variant: str, abs_key: str
+) -> None:
+    result = await resolve(concept)
+    assert result.source == "abs"
+    assert result.dataset_id == dataset_id
+    assert result.variant == variant
+    assert result.abs_key == abs_key
+
+
+@pytest.mark.parametrize(("concept", "dataset_id", "variant", "series_ids"), TRANCHE_A_RBA)
+@pytest.mark.asyncio
+async def test_resolve_tranche_a_rba_concepts(
+    concept: str, dataset_id: str, variant: str, series_ids: list[str]
+) -> None:
+    result = await resolve(concept)
+    assert result.source == "rba"
+    assert result.dataset_id == dataset_id
+    assert result.variant == variant
+    assert result.rba_series_ids == series_ids

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -279,7 +279,7 @@ def test_resolve_rba_csv_path_uses_explicit_csv_path_when_declared() -> None:
         del RBA_CATALOGUE["__test__"]
 
 
-def test_curated_shortcuts_cover_v0110_tranche_a_concepts() -> None:
+def test_curated_shortcuts_cover_v0110_tranches_ab_concepts() -> None:
     assert set(CURATED_SHORTCUTS) == {
         "cash_rate_target",
         "headline_cpi",
@@ -298,7 +298,63 @@ def test_curated_shortcuts_cover_v0110_tranche_a_concepts() -> None:
         "government_bond_yield_3y",
         "government_bond_yield_10y",
         "housing_credit",
+        # Tranche B
+        "business_credit",
+        "current_account_balance",
+        "underemployment_rate",
+        "hours_worked",
+        "job_vacancies",
+        "mortgage_rate",
+        "business_lending_rate",
+        "population",
+        "inflation_expectations",
+        "producer_price_inflation",
+        "household_spending",
+        "commodity_prices",
     }
+
+
+TRANCHE_B_ABS = [
+    ("current_account_balance", "BOP", "current_account", "1.100.20.Q"),
+    ("underemployment_rate", "LF_UNDER", "headline_underemployment", "M23.3.1599.20.AUS.M"),
+    ("hours_worked", "LF_HOURS", "headline_hours", "M18.3.1599.TOT.20.AUS.M"),
+    ("job_vacancies", "JV", "headline_vacancies", "M1.7.TOT.20.AUS.Q"),
+    ("population", "ERP_Q", "headline_population", "1.3.TOT.AUS.Q"),
+    ("producer_price_inflation", "PPI_FD", "producer", "3.TOT.TOT.TOTXE.Q"),
+    ("household_spending", "HSI_M", "headline_spending", "7.TOT.CUR.20.AUS.M"),
+]
+
+TRANCHE_B_RBA = [
+    ("business_credit", "d2", "business", ["DLCACBS"]),
+    ("mortgage_rate", "f6", "owner_occupier_variable", ["FLRHOOVA"]),
+    ("business_lending_rate", "f7", "small_business_indicator", ["FLRBFOSBT"]),
+    ("inflation_expectations", "g3", "consumer", ["GCONEXP"]),
+    ("commodity_prices", "i2", "rba_commodity_index", ["GRCPAISDR"]),
+]
+
+
+@pytest.mark.parametrize(("concept", "dataset_id", "variant", "abs_key"), TRANCHE_B_ABS)
+@pytest.mark.asyncio
+async def test_resolve_tranche_b_abs_concepts(
+    concept: str, dataset_id: str, variant: str, abs_key: str
+) -> None:
+    result = await resolve(concept)
+    assert result.source == "abs"
+    assert result.dataset_id == dataset_id
+    assert result.variant == variant
+    assert result.abs_key == abs_key
+
+
+@pytest.mark.parametrize(("concept", "dataset_id", "variant", "series_ids"), TRANCHE_B_RBA)
+@pytest.mark.asyncio
+async def test_resolve_tranche_b_rba_concepts(
+    concept: str, dataset_id: str, variant: str, series_ids: list[str]
+) -> None:
+    result = await resolve(concept)
+    assert result.source == "rba"
+    assert result.dataset_id == dataset_id
+    assert result.variant == variant
+    assert result.rba_series_ids == series_ids
 
 
 TRANCHE_A_ABS = [

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -9,6 +9,7 @@ from ausecon_mcp.catalogue.resolver import (
     build_abs_key,
     resolve,
     resolve_abs_dataflow_id,
+    resolve_abs_structure_id,
     resolve_rba_csv_path,
 )
 from ausecon_mcp.parsers.abs_structure import parse_abs_structure
@@ -229,6 +230,41 @@ def test_resolve_abs_dataflow_id_returns_upstream_id_when_declared() -> None:
         assert resolve_abs_dataflow_id("__TEST__") == "REAL_ID"
     finally:
         del ABS_CATALOGUE["__TEST__"]
+
+
+def test_resolve_abs_structure_id_passes_through_unknown_keys() -> None:
+    assert resolve_abs_structure_id("NOT_IN_CATALOGUE") == "NOT_IN_CATALOGUE"
+
+
+def test_resolve_abs_structure_id_falls_back_to_dataflow_id_when_not_declared() -> None:
+    assert resolve_abs_structure_id("CPI") == "CPI"
+
+
+def test_resolve_abs_structure_id_returns_structure_id_for_lf_under() -> None:
+    assert resolve_abs_structure_id("LF_UNDER") == "DS_LF_UNDER"
+
+
+@pytest.mark.asyncio
+async def test_resolve_lf_under_uses_mapped_structure_id_for_fetch() -> None:
+    captured: list[str] = []
+
+    async def fetcher(dataflow_id: str) -> dict:
+        captured.append(dataflow_id)
+        return {
+            "id": dataflow_id,
+            "dimensions": [
+                {
+                    "id": "MEASURE",
+                    "position": 1,
+                    "values": [{"code": "M23"}],
+                },
+                {"id": "FREQ", "position": 2, "values": [{"code": "M"}]},
+            ],
+        }
+
+    await resolve("LF_UNDER", frequency="M", abs_structure_fetcher=fetcher)
+
+    assert captured == ["DS_LF_UNDER"]
 
 
 def test_resolve_rba_csv_path_defaults_to_id_pattern() -> None:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,6 +5,7 @@ from fastmcp import Client
 
 from ausecon_mcp.catalogue.abs import ABS_CATALOGUE
 from ausecon_mcp.catalogue.rba import RBA_CATALOGUE
+from ausecon_mcp.catalogue.resolver import CURATED_SHORTCUTS
 from ausecon_mcp.server import build_server
 
 
@@ -46,6 +47,21 @@ async def test_rba_resource_returns_full_catalogue_entry() -> None:
         payload = await _read_json(client, "ausecon://rba/g1")
 
     assert payload == RBA_CATALOGUE["g1"]
+
+
+async def test_concepts_resource_lists_every_curated_shortcut() -> None:
+    mcp = build_server()
+
+    async with Client(mcp) as client:
+        payload = await _read_json(client, "ausecon://concepts")
+
+    concepts = {row["concept"] for row in payload}
+    assert concepts == set(CURATED_SHORTCUTS)
+    for row in payload:
+        expected = CURATED_SHORTCUTS[row["concept"]]
+        assert row["source"] == expected["source"]
+        assert row["dataset_id"] == expected["dataset_id"]
+        assert row["variant"] == expected.get("variant")
 
 
 async def test_abs_resource_raises_for_unknown_dataflow_id() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -428,7 +428,8 @@ async def test_list_catalogue_unfiltered_returns_abs_and_rba_entries() -> None:
 
     sources = {row["source"] for row in rows}
     assert sources == {"abs", "rba"}
-    assert all(row.keys() == {"id", "source", "name", "category", "frequency", "tags"} for row in rows)
+    expected_keys = {"id", "source", "name", "category", "frequency", "tags"}
+    assert all(row.keys() == expected_keys for row in rows)
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -244,7 +244,7 @@ async def test_service_rejects_unpopulated_rba_variant() -> None:
     service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
 
     with pytest.raises(ValueError, match="rba_series_ids populated"):
-        await service.get_economic_series("trimmed_mean_inflation", variant="weighted_median")
+        await service.get_economic_series("g3", variant="market")
 
 
 @pytest.mark.asyncio
@@ -369,6 +369,55 @@ async def test_service_defaults_rba_csv_path_when_not_declared() -> None:
 
     assert rba_provider.last_get_table_kwargs is not None
     assert rba_provider.last_get_table_kwargs["csv_path"] == "f16-data.csv"
+
+
+TRANCHE_A_ABS_SERVICE = [
+    ("employment", "LF", "M3.3.1599.20.AUS.M"),
+    ("unemployment_rate", "LF", "M13.3.1599.20.AUS.M"),
+    ("participation_rate", "LF", "M12.3.1599.20.AUS.M"),
+    ("wage_growth", "WPI", "3.THRPEB.7.TOT.20.AUS.Q"),
+    ("trade_balance", "ITGS", "M1.170.20.AUS.M"),
+]
+
+TRANCHE_A_RBA_SERVICE = [
+    ("weighted_median_inflation", "g1", ["GCPIOCPMWMYP"]),
+    ("monthly_inflation", "g4", ["GCPIAGSAMP"]),
+    ("aud_usd", "f11", ["FXRUSD"]),
+    ("trade_weighted_index", "f11", ["FXRTWI"]),
+    ("government_bond_yield_3y", "f17", ["FZCY300D"]),
+    ("government_bond_yield_10y", "f17", ["FZCY1000D"]),
+    ("housing_credit", "d2", ["DLCACOHS", "DLCACIHS"]),
+]
+
+
+@pytest.mark.parametrize(("concept", "dataflow_id", "abs_key"), TRANCHE_A_ABS_SERVICE)
+@pytest.mark.asyncio
+async def test_service_forwards_tranche_a_abs_concepts(
+    concept: str, dataflow_id: str, abs_key: str
+) -> None:
+    abs_provider = StubABSProvider()
+    service = AuseconService(abs_provider=abs_provider, rba_provider=StubRBAProvider())
+
+    await service.get_economic_series(concept)
+
+    assert abs_provider.last_get_data_kwargs is not None
+    assert abs_provider.last_get_data_kwargs["dataflow_id"] == dataflow_id
+    assert abs_provider.last_get_data_kwargs["key"] == abs_key
+
+
+@pytest.mark.parametrize(("concept", "table_id", "series_ids"), TRANCHE_A_RBA_SERVICE)
+@pytest.mark.asyncio
+async def test_service_forwards_tranche_a_rba_concepts(
+    concept: str, table_id: str, series_ids: list[str]
+) -> None:
+    rba = StubRBAProvider()
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=rba)
+
+    await service.get_economic_series(concept)
+
+    assert rba.last_get_table_kwargs is not None
+    assert rba.last_get_table_kwargs["table_id"] == table_id
+    assert rba.last_get_table_kwargs["series_ids"] == series_ids
 
 
 async def test_service_resolves_abs_upstream_id_before_calling_provider() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -420,6 +420,55 @@ async def test_service_forwards_tranche_a_rba_concepts(
     assert rba.last_get_table_kwargs["series_ids"] == series_ids
 
 
+TRANCHE_B_ABS_SERVICE = [
+    ("current_account_balance", "BOP", "1.100.20.Q"),
+    ("underemployment_rate", "LF_UNDER", "M23.3.1599.20.AUS.M"),
+    ("hours_worked", "LF_HOURS", "M18.3.1599.TOT.20.AUS.M"),
+    ("job_vacancies", "JV", "M1.7.TOT.20.AUS.Q"),
+    ("population", "ERP_Q", "1.3.TOT.AUS.Q"),
+    ("producer_price_inflation", "PPI_FD", "3.TOT.TOT.TOTXE.Q"),
+    ("household_spending", "HSI_M", "7.TOT.CUR.20.AUS.M"),
+]
+
+TRANCHE_B_RBA_SERVICE = [
+    ("business_credit", "d2", ["DLCACBS"]),
+    ("mortgage_rate", "f6", ["FLRHOOVA"]),
+    ("business_lending_rate", "f7", ["FLRBFOSBT"]),
+    ("inflation_expectations", "g3", ["GCONEXP"]),
+    ("commodity_prices", "i2", ["GRCPAISDR"]),
+]
+
+
+@pytest.mark.parametrize(("concept", "dataflow_id", "abs_key"), TRANCHE_B_ABS_SERVICE)
+@pytest.mark.asyncio
+async def test_service_forwards_tranche_b_abs_concepts(
+    concept: str, dataflow_id: str, abs_key: str
+) -> None:
+    abs_provider = StubABSProvider()
+    service = AuseconService(abs_provider=abs_provider, rba_provider=StubRBAProvider())
+
+    await service.get_economic_series(concept)
+
+    assert abs_provider.last_get_data_kwargs is not None
+    assert abs_provider.last_get_data_kwargs["dataflow_id"] == dataflow_id
+    assert abs_provider.last_get_data_kwargs["key"] == abs_key
+
+
+@pytest.mark.parametrize(("concept", "table_id", "series_ids"), TRANCHE_B_RBA_SERVICE)
+@pytest.mark.asyncio
+async def test_service_forwards_tranche_b_rba_concepts(
+    concept: str, table_id: str, series_ids: list[str]
+) -> None:
+    rba = StubRBAProvider()
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=rba)
+
+    await service.get_economic_series(concept)
+
+    assert rba.last_get_table_kwargs is not None
+    assert rba.last_get_table_kwargs["table_id"] == table_id
+    assert rba.last_get_table_kwargs["series_ids"] == series_ids
+
+
 async def test_service_resolves_abs_upstream_id_before_calling_provider() -> None:
     abs_provider = StubABSProvider()
     service = AuseconService(abs_provider=abs_provider, rba_provider=StubRBAProvider())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -421,6 +421,81 @@ async def test_service_forwards_tranche_a_rba_concepts(
 
 
 @pytest.mark.asyncio
+async def test_list_catalogue_unfiltered_returns_abs_and_rba_entries() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    rows = await service.list_catalogue()
+
+    sources = {row["source"] for row in rows}
+    assert sources == {"abs", "rba"}
+    assert all(row.keys() == {"id", "source", "name", "category", "frequency", "tags"} for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_list_catalogue_filters_by_source() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    rows = await service.list_catalogue(source="rba")
+
+    assert rows
+    assert {row["source"] for row in rows} == {"rba"}
+
+
+@pytest.mark.asyncio
+async def test_list_catalogue_filters_by_category() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    rows = await service.list_catalogue(category="inflation")
+
+    assert rows
+    assert {row["category"] for row in rows} == {"inflation"}
+
+
+@pytest.mark.asyncio
+async def test_list_catalogue_filters_by_tag_case_insensitive() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    rows = await service.list_catalogue(tag="Yield Curve")
+
+    assert rows
+    assert any("yield curve" in [t.lower() for t in row["tags"]] for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_list_catalogue_excludes_ceased_and_discontinued_by_default() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    rows = await service.list_catalogue()
+    ids = {row["id"] for row in rows}
+
+    # BUSINESS_TURNOVER is ceased; a5 was un-discontinued but check no ceased/discontinued.
+    from ausecon_mcp.catalogue.abs import ABS_CATALOGUE
+    from ausecon_mcp.catalogue.rba import RBA_CATALOGUE
+
+    for entry in list(ABS_CATALOGUE.values()) + list(RBA_CATALOGUE.values()):
+        if entry.get("ceased") or entry.get("discontinued"):
+            assert entry["id"] not in ids
+
+
+@pytest.mark.asyncio
+async def test_list_catalogue_includes_ceased_when_opted_in() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    rows = await service.list_catalogue(include_ceased=True)
+    ids = {row["id"] for row in rows}
+
+    assert "BUSINESS_TURNOVER" in ids
+
+
+@pytest.mark.asyncio
+async def test_list_catalogue_rejects_unknown_source() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    with pytest.raises(ValueError, match="source"):
+        await service.list_catalogue(source="fred")
+
+
+@pytest.mark.asyncio
 async def test_service_forwards_last_n_to_abs_provider_for_semantic_call() -> None:
     abs_provider = StubABSProvider()
     service = AuseconService(abs_provider=abs_provider, rba_provider=StubRBAProvider())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -420,6 +420,36 @@ async def test_service_forwards_tranche_a_rba_concepts(
     assert rba.last_get_table_kwargs["series_ids"] == series_ids
 
 
+@pytest.mark.asyncio
+async def test_service_forwards_last_n_to_abs_provider_for_semantic_call() -> None:
+    abs_provider = StubABSProvider()
+    service = AuseconService(abs_provider=abs_provider, rba_provider=StubRBAProvider())
+
+    await service.get_economic_series("headline_cpi", last_n=4)
+
+    assert abs_provider.last_get_data_kwargs is not None
+    assert abs_provider.last_get_data_kwargs["last_n"] == 4
+
+
+@pytest.mark.asyncio
+async def test_service_forwards_last_n_to_rba_provider_for_semantic_call() -> None:
+    rba = StubRBAProvider()
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=rba)
+
+    await service.get_economic_series("cash_rate_target", last_n=12)
+
+    assert rba.last_get_table_kwargs is not None
+    assert rba.last_get_table_kwargs["last_n"] == 12
+
+
+@pytest.mark.asyncio
+async def test_service_rejects_non_positive_semantic_last_n() -> None:
+    service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
+
+    with pytest.raises(ValueError, match="last_n"):
+        await service.get_economic_series("cash_rate_target", last_n=0)
+
+
 TRANCHE_B_ABS_SERVICE = [
     ("current_account_balance", "BOP", "1.100.20.Q"),
     ("underemployment_rate", "LF_UNDER", "M23.3.1599.20.AUS.M"),


### PR DESCRIPTION
## Summary

Expands `get_economic_series` from a 4-concept demo to a broad product surface and lands the ergonomics/discovery items from the v0.11.0 roadmap.

**Semantic expansion (Tranches A + B):**
- 24 new curated concepts across prices, labour, activity, rates, FX, external sector, and credit — now 28 total.
- ABS structure-id hardening: new `resolve_abs_structure_id()` helper + optional `structure_id` on ABS catalogue entries. Required because `LF_UNDER` composes against `DS_LF_UNDER`.
- Catalogue variants populated on 10 ABS entries (LF, WPI, ITGS, LF_UNDER, LF_HOURS, JV, ERP_Q, BOP, PPI_FD, HSI_M) and 9 RBA entries (g1, g4, f11, f17, d2, f6, f7, g3, i2).

**Ergonomics:**
- `last_n` parameter on `get_economic_series`, forwarded to the underlying provider call.

**Discovery:**
- New `list_catalogue` tool (unranked complement to `search_datasets`, with source/category/tag/ceased/discontinued filters).
- New `ausecon://concepts` resource listing every curated shortcut with its resolved target.

**Prompts + docs:**
- Two new prompt templates: `labour_slack_snapshot`, `yield_curve_snapshot`.
- README refreshed with the full 28-concept grouped default-mapping tables, locked-default explainers (`f17` over `f16`, two-series `housing_credit`, `PPI_FD` over `PPI`, `LF_UNDER` → `DS_LF_UNDER`), and docs for the new tool, parameter, and resource.
- Design doc gains an Implementation Notes section recording the locked decisions.

## Test plan

- [x] `uv run ruff check src tests integration_tests scripts` — clean
- [x] `uv run pytest` — 407 passed
- [x] `uv run pytest integration_tests/test_semantic_live.py -v` — 10/10 live concepts green
- [x] `uv run python scripts/audit_catalogue.py` — 0 drift, 0 disappeared
- [ ] Integration workflow green on `v0.11.0-semantic-layer` branch