### PR TITLE
feat: close v0.13 coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-20
+
+### Added
+- New ABS catalogue entry `BUILDING_APPROVALS`, backed by live ABS dataflow
+  `BA_GCCSA`, with a national residential approvals default.
+- New semantic shortcut `dwelling_approvals` resolving to
+  `BUILDING_APPROVALS.headline_approvals`.
+- New maintainer docs at `docs/contributing.md`, a checked-in stdio client
+  smoke path at `scripts/mcp_client_smoke.py`, and a release migration note at
+  `docs/migration-v0.13.0.md`.
+
+### Changed
+- Runtime catalogue entries now expose only fully wired variants; placeholder
+  ABS and RBA variants are no longer public in resources or semantic
+  resolution.
+- `RT` has been re-activated after live validation showed the ABS retail trade
+  dataflow is current again.
+- `BUILDING_ACTIVITY` no longer carries `building approvals` aliasing now that
+  approvals have a dedicated live entry.
+
 ## [0.12.1] - 2026-04-19
 
 ### Fixed
@@ -349,7 +369,8 @@ Initial public release.
 - Initial curated catalogues for ABS and RBA, plus a four-concept
   `CURATED_SERIES` semantic shortcut map.
 
-[Unreleased]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v0.10.0...v0.11.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For new integrations that need an unranked browse surface, prefer
 
 ### Currently supported semantic concepts
 
-`get_economic_series` resolves 28 curated concepts across prices, labour, activity, monetary
+`get_economic_series` resolves 29 curated concepts across prices, labour, activity, monetary
 policy, financial markets, external sector, and credit. The full list is also available at runtime
 via the `ausecon://concepts` resource. Resolver variant rules are summarised in
 [`docs/variants.md`](docs/variants.md), and the retrieval contract is documented in
@@ -83,6 +83,7 @@ via the `ausecon://concepts` resource. Resolver variant rules are summarised in
 | --- | --- | --- |
 | `gdp_growth` | ABS `ANA_AGG` | Quarterly real GDP growth (`M2.GPM.20.AUS.Q`) |
 | `household_spending` | ABS `HSI_M` | Household Spending Indicator, Australia, seasonally adjusted, current prices |
+| `dwelling_approvals` | ABS `BUILDING_APPROVALS` | Residential dwelling approvals, Australia, monthly (`1.1.9.TOT.100.10.AUS.M`) |
 | `population` | ABS `ERP_Q` | Estimated resident population, Australia, quarterly |
 
 **Monetary policy and rates**
@@ -131,11 +132,16 @@ A few defaults deserve calling out explicitly:
 - **`underemployment_rate` uses `LF_UNDER`** (dataflow id) but composes its SDMX key against
   structure id `DS_LF_UNDER`, because the live ABS SDMX structure is exposed under the
   `DS_`-prefixed id.
+- **`dwelling_approvals` uses `BUILDING_APPROVALS` → `BA_GCCSA`** with the live national
+  residential approvals series. The current ABS approvals collection does not expose a clean
+  seasonally adjusted national residential default, so the shipped semantic default is the original
+  Australia total.
 
 `variant`, `geography`, and `frequency` are validated against the catalogue entry. For ABS
 datasets, populated variants can be literal SDMX keys or partial fragments that are completed
 against the live structure. For RBA tables, populated variants narrow the response to the declared
-series IDs. Variants that are declared but not yet populated raise a clear "not yet wired" error.
+series IDs. The runtime catalogue only exposes fully wired variants; future candidates stay in
+[`docs/variant_candidates.md`](docs/variant_candidates.md) until they have a real series binding.
 
 ## Discovery And Validation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,49 @@
+# Contributing
+
+`ausecon-mcp-server` is intentionally narrow: ABS + RBA only, stdio transport only, and a small
+curated semantic layer over source-native retrievals.
+
+## Local Setup
+
+Use Python 3.12 for local development:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv sync --python 3.12 --extra dev
+```
+
+## Standard Verification
+
+Run the normal local checks before opening a PR or cutting a tag:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run ruff check src tests
+env UV_CACHE_DIR=.uv-cache uv run pytest
+env UV_CACHE_DIR=.uv-cache uv run pytest integration_tests/ -v
+env UV_CACHE_DIR=.uv-cache uv run python scripts/audit_catalogue.py
+```
+
+## Real Client Smoke
+
+Before a release tag, run the checked-in stdio smoke path:
+
+```bash
+env UV_CACHE_DIR=.uv-cache uv run python scripts/mcp_client_smoke.py
+```
+
+This uses a real FastMCP stdio client transport and verifies:
+
+- `search_datasets`
+- `list_catalogue`
+- `get_abs_data`
+- `get_economic_series`
+
+The smoke path currently exercises the `BUILDING_APPROVALS` catalogue entry and the
+`dwelling_approvals` semantic shortcut because they are the newest pre-`v1.0.0` coverage additions.
+
+## Release Discipline
+
+- Keep the MCP tool surface stable unless there is a strong reason to break it.
+- Do not expose placeholder variants in the runtime catalogue.
+- Prefer audited upstream fixes over broad catalogue growth.
+- If an ABS or RBA replacement series is not cleanly source-native, defer it rather than shipping an
+  approximate semantic shortcut.

--- a/docs/coverage-audit-2026-04.md
+++ b/docs/coverage-audit-2026-04.md
@@ -3,6 +3,9 @@
 > **Status (2026-04-19): resolved in v0.10.0** — see
 > [Resolution](#resolution--v0100-2026-04-19) at the bottom for the item-by-item
 > outcome. The sections below preserve the original audit findings.
+>
+> **Follow-up (2026-04-20):** `RT` was re-validated live and is active again in
+> `v0.13.0`; `RPPI` remains ceased pending a clean like-for-like replacement.
 
 Phase 0 audit of every entry in `src/ausecon_mcp/catalogue/abs.py` and
 `src/ausecon_mcp/catalogue/rba.py` against live upstream sources.

--- a/docs/migration-v0.13.0.md
+++ b/docs/migration-v0.13.0.md
@@ -1,0 +1,29 @@
+# v0.13.0 Migration Notes
+
+## Public Surface Changes
+
+- `RT` is live again and is no longer suppressed from ordinary discovery.
+- `BUILDING_APPROVALS` is a new ABS catalogue entry backed by upstream dataflow `BA_GCCSA`.
+- `dwelling_approvals` is a new semantic shortcut resolving to the national residential approvals
+  series `1.1.9.TOT.100.10.AUS.M`.
+
+## Variant Cleanup
+
+Runtime catalogue entries now expose only fully wired variants.
+
+That means placeholder variants such as undeclared ABS `abs_key` values or undeclared RBA
+`rba_series_ids` are no longer visible through:
+
+- `get_economic_series`
+- `ausecon://abs/{dataflow_id}`
+- `ausecon://rba/{table_id}`
+- `ausecon://concepts`
+
+If you previously depended on a placeholder variant name that never had a live series binding, the
+runtime now treats it as an unknown variant. Use `get_abs_data` or `get_rba_table` directly until a
+real wired variant is added.
+
+## Deferred
+
+`RPPI` remains ceased in `v0.13.0`. A like-for-like live replacement was not cleanly auditable
+against the current time-series contract, so it has been left out of the semantic layer on purpose.

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -24,5 +24,6 @@ RBA catalogue variants declare one or more `rba_series_ids`. The resolver passes
 ## Resolver Rules
 
 - Unknown concepts and unsupported variants raise explicit validation errors.
-- Variants declared without a concrete ABS key or `rba_series_ids` raise a clear “not yet wired” error.
+- The runtime catalogue exposes only fully wired variants. Placeholder candidates stay in
+  `docs/variant_candidates.md` until they have a concrete ABS key or `rba_series_ids`.
 - The semantic layer only exposes curated source-native concepts. Derived concepts remain deferred until after the retrieval contract is stable.

--- a/integration_tests/test_abs_live.py
+++ b/integration_tests/test_abs_live.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from ausecon_mcp.providers.abs import ABSProvider
+from ausecon_mcp.server import AuseconService
 
 pytestmark = pytest.mark.asyncio
 
@@ -33,3 +34,17 @@ async def test_abs_cpi_data_returns_observations() -> None:
         assert field in obs, f"observation missing field {field!r}"
     assert result["metadata"]["source"] == "abs"
     assert isinstance(result["metadata"]["server_version"], str)
+
+
+async def test_abs_building_approvals_entry_returns_observations() -> None:
+    service = AuseconService()
+
+    result = await service.get_abs_data(
+        "BUILDING_APPROVALS",
+        key="1.1.9.TOT.100.10.AUS.M",
+        last_n=3,
+    )
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "BA_GCCSA"
+    assert result["observations"], "expected observations for BUILDING_APPROVALS"

--- a/integration_tests/test_semantic_live.py
+++ b/integration_tests/test_semantic_live.py
@@ -101,3 +101,11 @@ async def test_live_semantic_commodity_prices() -> None:
     assert result["metadata"]["dataset_id"] == "i2"
     series_ids = {s["series_id"] for s in result["series"]}
     assert "GRCPAISDR" in series_ids
+
+
+async def test_live_semantic_dwelling_approvals() -> None:
+    result = await _call("dwelling_approvals")
+
+    assert result["metadata"]["source"] == "abs"
+    assert result["metadata"]["dataset_id"] == "BA_GCCSA"
+    assert result["observations"]

--- a/scripts/mcp_client_smoke.py
+++ b/scripts/mcp_client_smoke.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client import UvStdioTransport
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+async def main() -> None:
+    transport = UvStdioTransport(
+        "ausecon-mcp-server",
+        project_directory=ROOT,
+        python_version="3.12",
+        env_vars={
+            "UV_CACHE_DIR": str(ROOT / ".uv-cache"),
+            "FASTMCP_SHOW_SERVER_BANNER": "false",
+            "FASTMCP_LOG_LEVEL": "ERROR",
+            "AUSECON_CACHE_DISABLED": "1",
+            "AUSECON_LOG_LEVEL": "ERROR",
+        },
+    )
+
+    async with Client(transport, name="ausecon-smoke") as client:
+        tools = await client.list_tools()
+        tool_names = {tool.name for tool in tools}
+        assert {
+            "search_datasets",
+            "list_catalogue",
+            "get_abs_data",
+            "get_economic_series",
+        } <= tool_names
+
+        search = await client.call_tool("search_datasets", {"query": "cash rate"})
+        assert search.data and search.data[0]["id"] == "a2"
+
+        catalogue = await client.call_tool(
+            "list_catalogue",
+            {"source": "abs", "category": "housing_construction"},
+        )
+        ids = {row["id"] for row in catalogue.data}
+        assert "BUILDING_APPROVALS" in ids
+
+        abs_data = await client.call_tool(
+            "get_abs_data",
+            {
+                "dataflow_id": "BUILDING_APPROVALS",
+                "key": "1.1.9.TOT.100.10.AUS.M",
+                "last_n": 3,
+            },
+        )
+        assert abs_data.data["metadata"]["source"] == "abs"
+        assert abs_data.data["observations"]
+
+        semantic = await client.call_tool(
+            "get_economic_series",
+            {"concept": "dwelling_approvals", "last_n": 3},
+        )
+        assert semantic.data["metadata"]["source"] == "abs"
+        assert semantic.data["observations"]
+
+    print("mcp-smoke-ok")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server.json
+++ b/server.json
@@ -3,13 +3,13 @@
   "name": "io.github.AnthonyPuggs/ausecon-mcp-server",
   "title": "Australian Economic Data (RBA & ABS)",
   "description": "Australian economic data from the RBA and ABS: CPI, GDP, cash rate, labour force, among others.",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "packages": [
     {
       "identifier": "ausecon-mcp-server",
       "registryType": "pypi",
       "runtimeHint": "uvx",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/ausecon_mcp/catalogue/_runtime.py
+++ b/src/ausecon_mcp/catalogue/_runtime.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+def strip_unwired_variants(
+    catalogue: dict[str, dict[str, Any]], *, key_name: str
+) -> dict[str, dict[str, Any]]:
+    """Return a runtime catalogue with only fully wired variants exposed."""
+    normalised = deepcopy(catalogue)
+    for entry in normalised.values():
+        variants = entry.get("variants", [])
+        entry["variants"] = [variant for variant in variants if variant.get(key_name) is not None]
+    return normalised

--- a/src/ausecon_mcp/catalogue/abs.py
+++ b/src/ausecon_mcp/catalogue/abs.py
@@ -1,4 +1,6 @@
-ABS_CATALOGUE = {
+from ausecon_mcp.catalogue._runtime import strip_unwired_variants
+
+_RAW_ABS_CATALOGUE = {
     "CPI": {
         "id": "CPI",
         "source": "abs",
@@ -688,10 +690,10 @@ ABS_CATALOGUE = {
     "RT": {
         "id": "RT",
         "source": "abs",
-        "name": "Retail Trade (Ceased)",
+        "name": "Retail Trade",
         "description": (
-            "Ceased monthly retail trade dataflow. Superseded by a new ABS monthly "
-            "retail indicator; retained here for historical reference."
+            "Monthly retail turnover by industry and geography, including original, "
+            "seasonally adjusted, and trend measures."
         ),
         "frequency": "Monthly",
         "category": "activity",
@@ -708,9 +710,8 @@ ABS_CATALOGUE = {
         "frequencies": ["M"],
         "geographies": ["national"],
         "variants": [],
-        "ceased": True,
         "audit": {
-            "last_audited": "2026-04-18",
+            "last_audited": "2026-04-20",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/RT/latest",
             "upstream_title": "Retail Trade",
         },
@@ -851,7 +852,6 @@ ABS_CATALOGUE = {
         "category": "housing_construction",
         "aliases": [
             "building activity",
-            "building approvals",
             "dwelling commencements",
             "building completions",
         ],
@@ -867,6 +867,45 @@ ABS_CATALOGUE = {
             "last_audited": "2026-04-18",
             "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/BUILDING_ACTIVITY/latest",
             "upstream_title": "Building Activity",
+        },
+    },
+    "BUILDING_APPROVALS": {
+        "id": "BUILDING_APPROVALS",
+        "source": "abs",
+        "upstream_id": "BA_GCCSA",
+        "name": "Building Approvals",
+        "description": (
+            "Monthly dwelling-unit approvals and building-job values from the live ABS "
+            "building approvals collection, with a national residential approvals default."
+        ),
+        "frequency": "Monthly",
+        "category": "housing_construction",
+        "aliases": [
+            "building approvals",
+            "dwelling approvals",
+            "residential approvals",
+        ],
+        "tags": [
+            "approvals",
+            "housing pipeline",
+            "new dwellings",
+        ],
+        "frequencies": ["M"],
+        "geographies": ["national"],
+        "variants": [
+            {
+                "name": "headline_approvals",
+                "aliases": ["dwelling approvals", "residential approvals"],
+                "abs_key": "1.1.9.TOT.100.10.AUS.M",
+            },
+        ],
+        "audit": {
+            "last_audited": "2026-04-20",
+            "upstream_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/BA_GCCSA/latest",
+            "upstream_title": (
+                "Building Approvals by Greater Capital Cities Statistical Area "
+                "(GCCSA) and above"
+            ),
         },
     },
     "CWD": {
@@ -1441,3 +1480,6 @@ ABS_CATALOGUE = {
         },
     },
 }
+
+
+ABS_CATALOGUE = strip_unwired_variants(_RAW_ABS_CATALOGUE, key_name="abs_key")

--- a/src/ausecon_mcp/catalogue/rba.py
+++ b/src/ausecon_mcp/catalogue/rba.py
@@ -1,4 +1,6 @@
-RBA_CATALOGUE = {
+from ausecon_mcp.catalogue._runtime import strip_unwired_variants
+
+_RAW_RBA_CATALOGUE = {
     "a1": {
         "id": "a1",
         "source": "rba",
@@ -1764,3 +1766,6 @@ RBA_CATALOGUE = {
         },
     },
 }
+
+
+RBA_CATALOGUE = strip_unwired_variants(_RAW_RBA_CATALOGUE, key_name="rba_series_ids")

--- a/src/ausecon_mcp/catalogue/resolver.py
+++ b/src/ausecon_mcp/catalogue/resolver.py
@@ -82,6 +82,11 @@ CURATED_SHORTCUTS: dict[str, dict[str, Any]] = {
     "headline_cpi": {"source": "abs", "dataset_id": "CPI", "variant": "headline"},
     "trimmed_mean_inflation": {"source": "rba", "dataset_id": "g1", "variant": "trimmed_mean"},
     "gdp_growth": {"source": "abs", "dataset_id": "ANA_AGG", "variant": "gdp_growth"},
+    "dwelling_approvals": {
+        "source": "abs",
+        "dataset_id": "BUILDING_APPROVALS",
+        "variant": "headline_approvals",
+    },
     # Tranche A
     "employment": {"source": "abs", "dataset_id": "LF", "variant": "employment"},
     "unemployment_rate": {"source": "abs", "dataset_id": "LF", "variant": "unemployment_rate"},

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -80,11 +80,18 @@ def test_search_catalogue_prefers_full_economist_query_matches() -> None:
 
 
 def test_search_catalogue_excludes_ceased_abs_dataflows() -> None:
-    for ceased_id in ("BUSINESS_TURNOVER", "CPI_M", "RT", "RPPI"):
+    for ceased_id in ("BUSINESS_TURNOVER", "CPI_M", "RPPI"):
         results = search_catalogue(ceased_id, source="abs")
         assert all(item["id"] != ceased_id for item in results), (
             f"{ceased_id} is marked ceased but still appeared in search results"
         )
+
+
+def test_search_catalogue_returns_reactivated_retail_trade() -> None:
+    results = search_catalogue("retail trade", source="abs")
+
+    assert results
+    assert results[0]["id"] == "RT"
 
 
 def test_slci_resolves_to_selected_living_cost_indexes() -> None:
@@ -107,30 +114,43 @@ def test_every_catalogue_entry_declares_resolver_schema_fields() -> None:
         assert isinstance(entry.get("variants"), list), entry["id"]
 
 
-def test_abs_variants_carry_name_aliases_and_optional_sdmx_key() -> None:
+def test_abs_variants_carry_name_aliases_and_wired_sdmx_key() -> None:
     for entry in ABS_CATALOGUE.values():
         for variant in entry["variants"]:
             assert isinstance(variant.get("name"), str) and variant["name"], entry["id"]
             assert isinstance(variant.get("aliases"), list), entry["id"]
             assert "abs_key" in variant, f"{entry['id']}/{variant['name']}"
             key = variant["abs_key"]
-            if key is not None:
-                assert isinstance(key, str) and SDMX_KEY_PATTERN.match(key), (
-                    f"{entry['id']}/{variant['name']}: {key!r} is not a valid SDMX key"
-                )
+            assert isinstance(key, str) and SDMX_KEY_PATTERN.match(key), (
+                f"{entry['id']}/{variant['name']}: {key!r} is not a valid wired SDMX key"
+            )
 
 
-def test_rba_variants_carry_name_aliases_and_optional_series_ids() -> None:
+def test_rba_variants_carry_name_aliases_and_wired_series_ids() -> None:
     for entry in RBA_CATALOGUE.values():
         for variant in entry["variants"]:
             assert isinstance(variant.get("name"), str) and variant["name"], entry["id"]
             assert isinstance(variant.get("aliases"), list), entry["id"]
             assert "rba_series_ids" in variant, f"{entry['id']}/{variant['name']}"
             series_ids = variant["rba_series_ids"]
-            if series_ids is not None:
-                assert isinstance(series_ids, list) and series_ids, (
-                    f"{entry['id']}/{variant['name']}: rba_series_ids must be None or non-empty"
-                )
-                assert all(isinstance(s, str) and s for s in series_ids), (
-                    f"{entry['id']}/{variant['name']}: all series ids must be non-empty strings"
-                )
+            assert isinstance(series_ids, list) and series_ids, (
+                f"{entry['id']}/{variant['name']}: rba_series_ids must be wired and non-empty"
+            )
+            assert all(isinstance(s, str) and s for s in series_ids), (
+                f"{entry['id']}/{variant['name']}: all series ids must be non-empty strings"
+            )
+
+
+def test_building_approvals_entry_has_wired_default_variant() -> None:
+    entry = ABS_CATALOGUE["BUILDING_APPROVALS"]
+
+    assert entry["name"] == "Building Approvals"
+    assert entry["frequency"] == "Monthly"
+    assert entry["category"] == "housing_construction"
+    assert entry["variants"] == [
+        {
+            "name": "headline_approvals",
+            "aliases": ["dwelling approvals", "residential approvals"],
+            "abs_key": "1.1.9.TOT.100.10.AUS.M",
+        }
+    ]

--- a/tests/test_repository_hygiene.py
+++ b/tests/test_repository_hygiene.py
@@ -17,6 +17,8 @@ CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 SERVER_JSON = ROOT / "server.json"
 CHANGELOG = ROOT / "CHANGELOG.md"
+CONTRIBUTING = ROOT / "docs" / "contributing.md"
+CLIENT_SMOKE = ROOT / "scripts" / "mcp_client_smoke.py"
 
 
 def test_readme_and_example_advertise_pypi_uvx_install() -> None:
@@ -102,6 +104,21 @@ def test_contract_and_architecture_docs_exist() -> None:
     assert (ROOT / "docs" / "architecture.md").is_file()
     assert (ROOT / "docs" / "variants.md").is_file()
     assert (ROOT / "docs" / "response-schema.md").is_file()
+    assert CONTRIBUTING.is_file()
+
+
+def test_contributing_doc_mentions_client_smoke_path() -> None:
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+
+    assert "mcp_client_smoke.py" in text
+    assert "search_datasets" in text
+    assert "list_catalogue" in text
+    assert "get_abs_data" in text
+    assert "get_economic_series" in text
+
+
+def test_client_smoke_script_exists() -> None:
+    assert CLIENT_SMOKE.is_file()
 
 
 def test_release_workflow_smoke_tests_built_wheel() -> None:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -76,8 +76,8 @@ async def test_resolve_rba_variant_returns_populated_series_ids() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_rba_unpopulated_variant_raises() -> None:
-    with pytest.raises(ValueError, match="rba_series_ids populated"):
+async def test_resolve_removed_runtime_variant_is_unknown() -> None:
+    with pytest.raises(ValueError, match="Unknown variant"):
         await resolve("g3", variant="market")
 
 
@@ -285,6 +285,7 @@ def test_curated_shortcuts_cover_v0110_tranches_ab_concepts() -> None:
         "headline_cpi",
         "trimmed_mean_inflation",
         "gdp_growth",
+        "dwelling_approvals",
         # Tranche A
         "employment",
         "unemployment_rate",
@@ -312,6 +313,16 @@ def test_curated_shortcuts_cover_v0110_tranches_ab_concepts() -> None:
         "household_spending",
         "commodity_prices",
     }
+
+
+@pytest.mark.asyncio
+async def test_resolve_dwelling_approvals_defaults_to_live_abs_key() -> None:
+    result = await resolve("dwelling_approvals")
+
+    assert result.source == "abs"
+    assert result.dataset_id == "BUILDING_APPROVALS"
+    assert result.variant == "headline_approvals"
+    assert result.abs_key == "1.1.9.TOT.100.10.AUS.M"
 
 
 TRANCHE_B_ABS = [

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -38,6 +38,13 @@ async def test_abs_resource_returns_full_catalogue_entry() -> None:
         payload = await _read_json(client, "ausecon://abs/CPI")
 
     assert payload == ABS_CATALOGUE["CPI"]
+    assert payload["variants"] == [
+        {
+            "name": "headline",
+            "aliases": ["headline cpi", "all groups"],
+            "abs_key": "1.10001.10.50.Q",
+        }
+    ]
 
 
 async def test_rba_resource_returns_full_catalogue_entry() -> None:
@@ -62,6 +69,22 @@ async def test_concepts_resource_lists_every_curated_shortcut() -> None:
         assert row["source"] == expected["source"]
         assert row["dataset_id"] == expected["dataset_id"]
         assert row["variant"] == expected.get("variant")
+
+
+async def test_abs_resource_exposes_new_building_approvals_entry() -> None:
+    mcp = build_server()
+
+    async with Client(mcp) as client:
+        payload = await _read_json(client, "ausecon://abs/BUILDING_APPROVALS")
+
+    assert payload == ABS_CATALOGUE["BUILDING_APPROVALS"]
+    assert payload["variants"] == [
+        {
+            "name": "headline_approvals",
+            "aliases": ["dwelling approvals", "residential approvals"],
+            "abs_key": "1.1.9.TOT.100.10.AUS.M",
+        }
+    ]
 
 
 async def test_abs_resource_raises_for_unknown_dataflow_id() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -240,11 +240,23 @@ async def test_service_forwards_default_abs_key_for_gdp_growth() -> None:
 
 
 @pytest.mark.asyncio
-async def test_service_rejects_unpopulated_rba_variant() -> None:
+async def test_service_rejects_removed_runtime_rba_variant() -> None:
     service = AuseconService(abs_provider=StubABSProvider(), rba_provider=StubRBAProvider())
 
-    with pytest.raises(ValueError, match="rba_series_ids populated"):
+    with pytest.raises(ValueError, match="Unknown variant"):
         await service.get_economic_series("g3", variant="market")
+
+
+@pytest.mark.asyncio
+async def test_service_forwards_default_abs_key_for_dwelling_approvals() -> None:
+    abs_provider = StubABSProvider()
+    service = AuseconService(abs_provider=abs_provider, rba_provider=StubRBAProvider())
+
+    await service.get_economic_series("dwelling_approvals")
+
+    assert abs_provider.last_get_data_kwargs is not None
+    assert abs_provider.last_get_data_kwargs["dataflow_id"] == "BA_GCCSA"
+    assert abs_provider.last_get_data_kwargs["key"] == "1.1.9.TOT.100.10.AUS.M"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore live ABS coverage for retail trade, add dedicated building approvals coverage, and wire the `dwelling_approvals` semantic shortcut
- remove unwired runtime catalogue variants and document the release-policy cleanup for `v0.13.0`
- add the contributing guide, migration note, and checked-in FastMCP client smoke path for pre-tag verification

## Test Plan
- [x] `env UV_CACHE_DIR=.uv-cache RUFF_CACHE_DIR=/tmp/ausecon-ruff-cache uv run ruff check src tests integration_tests scripts`
- [x] `env UV_CACHE_DIR=.uv-cache uv run pytest`
- [x] `env UV_CACHE_DIR=.uv-cache uv run pytest integration_tests/ -v`
- [x] `env UV_CACHE_DIR=.uv-cache uv run python scripts/audit_catalogue.py`
- [x] `env UV_CACHE_DIR=.uv-cache uv run python scripts/mcp_client_smoke.py`