### PR TITLE
feat: derived alignment_method + ex-post real-rate disclosures

### DIFF
--- a/schemas/response.schema.json
+++ b/schemas/response.schema.json
@@ -376,6 +376,7 @@
         "operands",
         "source_concepts",
         "alignment_frequency",
+        "alignment_method",
         "units",
         "requested_bounds",
         "resolved_bounds",
@@ -403,6 +404,10 @@
         },
         "alignment_frequency": {
           "type": "string"
+        },
+        "alignment_method": {
+          "type": "string",
+          "enum": ["locf", "exact_month", "period_intersection", "year_ended_lag"]
         },
         "units": {
           "type": "string"

--- a/src/ausecon_mcp/derived.py
+++ b/src/ausecon_mcp/derived.py
@@ -283,7 +283,11 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
     "real_cash_rate": DerivedSpec(
         concept="real_cash_rate",
         label="Real cash rate",
-        description="RBA cash-rate target less complete monthly CPI year-ended inflation.",
+        description=(
+            "RBA cash-rate target less complete monthly CPI year-ended inflation. "
+            "This is an ex-post real rate (the nominal rate less realised year-ended "
+            "CPI inflation), not the ex-ante Fisher rate (less expected inflation)."
+        ),
         frequency="Monthly",
         unit="percentage points",
         formula="cash_rate_target - monthly_inflation",
@@ -354,7 +358,11 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
     "real_mortgage_rate": DerivedSpec(
         concept="real_mortgage_rate",
         label="Real mortgage rate",
-        description="Owner-occupier variable mortgage rate less complete monthly CPI inflation.",
+        description=(
+            "Owner-occupier variable mortgage rate less complete monthly CPI inflation. "
+            "This is an ex-post real rate (the nominal rate less realised year-ended "
+            "CPI inflation), not the ex-ante Fisher rate (less expected inflation)."
+        ),
         frequency="Monthly",
         unit="percentage points",
         formula="mortgage_rate - monthly_inflation",
@@ -395,7 +403,9 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         label="Real 10-year bond yield",
         description=(
             "Ten-year Australian government bond yield less complete monthly CPI "
-            "year-ended inflation."
+            "year-ended inflation. This is an ex-post real rate (the nominal rate "
+            "less realised year-ended CPI inflation), not the ex-ante Fisher rate "
+            "(less expected inflation)."
         ),
         frequency="Monthly",
         unit="percentage points",
@@ -411,7 +421,9 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         concept="real_bank_bill_rate",
         label="Real bank bill rate",
         description=(
-            "Three-month bank bill swap rate less complete monthly CPI year-ended inflation."
+            "Three-month bank bill swap rate less complete monthly CPI year-ended inflation. "
+            "This is an ex-post real rate (the nominal rate less realised year-ended "
+            "CPI inflation), not the ex-ante Fisher rate (less expected inflation)."
         ),
         frequency="Monthly",
         unit="percentage points",
@@ -427,7 +439,9 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         concept="real_business_lending_rate",
         label="Real business lending rate",
         description=(
-            "Small-business indicator lending rate less complete monthly CPI year-ended inflation."
+            "Small-business indicator lending rate less complete monthly CPI year-ended inflation. "
+            "This is an ex-post real rate (the nominal rate less realised year-ended "
+            "CPI inflation), not the ex-ante Fisher rate (less expected inflation)."
         ),
         frequency="Monthly",
         unit="percentage points",

--- a/src/ausecon_mcp/derived.py
+++ b/src/ausecon_mcp/derived.py
@@ -41,6 +41,7 @@ class DerivedSpec:
     frequency: Literal["Daily", "Monthly", "Quarterly"]
     unit: str
     formula: str
+    alignment_method: Literal["locf", "exact_month", "period_intersection", "year_ended_lag"]
     operands: tuple[OperandSpec, ...]
     compute: Callable[[dict[str, dict[str, float]]], list[tuple[str, float]]]
 
@@ -272,6 +273,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Daily",
         unit="percentage points",
         formula="government_bond_yield_10y - government_bond_yield_3y",
+        alignment_method="period_intersection",
         operands=(
             OperandSpec("long_yield", "government_bond_yield_10y"),
             OperandSpec("short_yield", "government_bond_yield_3y"),
@@ -285,6 +287,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percentage points",
         formula="cash_rate_target - monthly_inflation",
+        alignment_method="locf",
         operands=(
             OperandSpec("cash_rate", "cash_rate_target"),
             OperandSpec("inflation", "monthly_inflation"),
@@ -300,6 +303,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Quarterly",
         unit="percentage points",
         formula="wage_growth - headline_cpi_yoy",
+        alignment_method="period_intersection",
         operands=(
             OperandSpec("wage_growth", "wage_growth"),
             OperandSpec("cpi_index", "headline_cpi"),
@@ -313,6 +317,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percent year-ended",
         formula="100 * (total_credit_t / total_credit_t-12 - 1)",
+        alignment_method="year_ended_lag",
         operands=(OperandSpec("total_credit", "total_credit"),),
         compute=_compute_credit_growth,
     ),
@@ -323,6 +328,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Quarterly",
         unit="real AUD per person",
         formula="real_gdp * 1_000_000 / population",
+        alignment_method="period_intersection",
         operands=(
             OperandSpec("real_gdp", "real_gdp"),
             OperandSpec("population", "population"),
@@ -338,6 +344,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percentage points",
         formula="mortgage_rate - bank_bill_rate",
+        alignment_method="locf",
         operands=(
             OperandSpec("mortgage_rate", "mortgage_rate"),
             OperandSpec("bank_bill_rate", "bank_bill_rate"),
@@ -351,6 +358,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percentage points",
         formula="mortgage_rate - monthly_inflation",
+        alignment_method="period_intersection",
         operands=(
             OperandSpec("mortgage_rate", "mortgage_rate"),
             OperandSpec("inflation", "monthly_inflation"),
@@ -364,6 +372,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Quarterly",
         unit="percent",
         formula="100 * total_credit / nominal_gdp",
+        alignment_method="locf",
         operands=(
             OperandSpec("total_credit", "total_credit"),
             OperandSpec("nominal_gdp", "nominal_gdp"),
@@ -377,6 +386,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Quarterly",
         unit="percent year-ended",
         formula="100 * (household_spending_t / household_spending_t-4 - 1)",
+        alignment_method="year_ended_lag",
         operands=(OperandSpec("household_spending", "quarterly_household_spending_volume"),),
         compute=_compute_household_spending_growth,
     ),
@@ -390,6 +400,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percentage points",
         formula="government_bond_yield_10y - monthly_inflation",
+        alignment_method="locf",
         operands=(
             OperandSpec("bond_yield", "government_bond_yield_10y"),
             OperandSpec("inflation", "monthly_inflation"),
@@ -405,6 +416,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percentage points",
         formula="bank_bill_rate - monthly_inflation",
+        alignment_method="locf",
         operands=(
             OperandSpec("bank_bill_rate", "bank_bill_rate"),
             OperandSpec("inflation", "monthly_inflation"),
@@ -420,6 +432,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percentage points",
         formula="business_lending_rate - monthly_inflation",
+        alignment_method="exact_month",
         operands=(
             OperandSpec("lending_rate", "business_lending_rate"),
             OperandSpec("inflation", "monthly_inflation"),
@@ -433,6 +446,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percent year-ended",
         formula="100 * (broad_money_t / broad_money_t-12 - 1)",
+        alignment_method="year_ended_lag",
         operands=(OperandSpec("broad_money", "broad_money"),),
         compute=_compute_broad_money_growth,
     ),
@@ -443,6 +457,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percent year-ended",
         formula="100 * (employment_t / employment_t-12 - 1)",
+        alignment_method="year_ended_lag",
         operands=(OperandSpec("employment", "employment"),),
         compute=_compute_employment_growth,
     ),
@@ -455,6 +470,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Monthly",
         unit="percentage points",
         formula="unemployment_rate + monthly_inflation",
+        alignment_method="period_intersection",
         operands=(
             OperandSpec("unemployment_rate", "unemployment_rate"),
             OperandSpec("inflation", "monthly_inflation"),
@@ -471,6 +487,7 @@ DERIVED_CONCEPTS: dict[str, DerivedSpec] = {
         frequency="Quarterly",
         unit="index",
         formula="100 * export_price_index / import_price_index",
+        alignment_method="period_intersection",
         operands=(
             OperandSpec("export_prices", "export_price_index"),
             OperandSpec("import_prices", "import_price_index"),

--- a/src/ausecon_mcp/derived.py
+++ b/src/ausecon_mcp/derived.py
@@ -639,6 +639,7 @@ def derive_series(
                 ],
                 "source_concepts": [operand.concept for operand in spec.operands],
                 "alignment_frequency": spec.frequency,
+                "alignment_method": spec.alignment_method,
                 "units": spec.unit,
                 "requested_bounds": {"start": requested_start, "end": requested_end},
                 "resolved_bounds": {"start": resolved_start, "end": resolved_end},

--- a/src/ausecon_mcp/schemas/response.schema.json
+++ b/src/ausecon_mcp/schemas/response.schema.json
@@ -376,6 +376,7 @@
         "operands",
         "source_concepts",
         "alignment_frequency",
+        "alignment_method",
         "units",
         "requested_bounds",
         "resolved_bounds",
@@ -403,6 +404,10 @@
         },
         "alignment_frequency": {
           "type": "string"
+        },
+        "alignment_method": {
+          "type": "string",
+          "enum": ["locf", "exact_month", "period_intersection", "year_ended_lag"]
         },
         "units": {
           "type": "string"

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -701,6 +701,20 @@ def test_terms_of_trade_metadata_carries_alignment_method() -> None:
     assert payload["metadata"]["derived"]["alignment_method"] == "period_intersection"
 
 
+@pytest.mark.parametrize(
+    "concept",
+    [
+        "real_cash_rate",
+        "real_10y_bond_yield",
+        "real_bank_bill_rate",
+        "real_business_lending_rate",
+        "real_mortgage_rate",
+    ],
+)
+def test_real_rate_descriptions_state_ex_post(concept: str) -> None:
+    assert "ex-post" in DERIVED_CONCEPTS[concept].description.lower()
+
+
 def test_derive_series_rejects_start_after_end() -> None:
     with pytest.raises(ValueError, match="start must be before or equal to end"):
         derive_series(

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -667,6 +667,40 @@ def test_every_derived_concept_declares_a_valid_alignment_method() -> None:
         assert spec.alignment_method in _VALID_ALIGNMENT_METHODS, name
 
 
+def test_terms_of_trade_metadata_carries_alignment_method() -> None:
+    payload = derive_series(
+        "terms_of_trade",
+        {
+            "export_prices": _payload(
+                concept="export_price_index",
+                source="abs",
+                dataset_id="ITPI_EXP",
+                series_id="MEASURE=1|INDEX=8093697|FREQ=Q",
+                observations=[("2025-Q4", 157.8), ("2026-Q1", 158.6)],
+                frequency="Quarterly",
+                unit="Index Numbers",
+                abs_key="1.8093697.Q",
+            ),
+            "import_prices": _payload(
+                concept="import_price_index",
+                source="abs",
+                dataset_id="ITPI_IMP",
+                series_id="MEASURE=1|INDEX=6011001|FREQ=Q",
+                observations=[("2025-Q4", 135.4), ("2026-Q1", 135.5)],
+                frequency="Quarterly",
+                unit="Index Numbers",
+                abs_key="1.6011001.Q",
+            ),
+        },
+        requested_start=None,
+        requested_end=None,
+        last_n=None,
+        server_version="test",
+    )
+
+    assert payload["metadata"]["derived"]["alignment_method"] == "period_intersection"
+
+
 def test_derive_series_rejects_start_after_end() -> None:
     with pytest.raises(ValueError, match="start must be before or equal to end"):
         derive_series(

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from ausecon_mcp.derived import derive_series, list_derived_concepts
+from ausecon_mcp.derived import DERIVED_CONCEPTS, derive_series, list_derived_concepts
 
 
 def _payload(
@@ -652,6 +652,19 @@ def test_terms_of_trade_ratios_export_to_import_prices() -> None:
         "100 * export_price_index / import_price_index"
     )
     assert payload["series"][0]["unit"] == "index"
+
+
+_VALID_ALIGNMENT_METHODS = {
+    "locf",
+    "exact_month",
+    "period_intersection",
+    "year_ended_lag",
+}
+
+
+def test_every_derived_concept_declares_a_valid_alignment_method() -> None:
+    for name, spec in DERIVED_CONCEPTS.items():
+        assert spec.alignment_method in _VALID_ALIGNMENT_METHODS, name
 
 
 def test_derive_series_rejects_start_after_end() -> None:


### PR DESCRIPTION
Closes the methodology-disclosure items from the 14 June code review.

- Adds a required `alignment_method` to every `DerivedSpec` (16 concepts; `locf` / `exact_month` / `period_intersection` / `year_ended_lag`), verified against each `_compute_*`.
- Surfaces it in `metadata.derived` and adds it to both copies of the response JSON schema (`required` + enum).
- Appends an explicit ex-post disclosure to the five real-rate concept descriptions.

822 tests pass; ruff clean. Independent of the other two PRs (no conflicts).