### PR TITLE
feat: cheap ABS latest-value path via lastNObservations (P0.3)

### DIFF
--- a/src/ausecon_mcp/providers/abs.py
+++ b/src/ausecon_mcp/providers/abs.py
@@ -120,10 +120,11 @@ class ABSProvider:
         end_period: str | None = None,
         last_n: int | None = None,
         updated_after: str | None = None,
+        latest_n: int | None = None,
     ) -> dict[str, Any]:
         # Structured encoding so a literal "None" value can never alias an absent one.
         cache_key = "abs-data:" + json.dumps(
-            [dataflow_id, key, start_period, end_period, updated_after]
+            [dataflow_id, key, start_period, end_period, updated_after, latest_n]
         )
         raw_payload = self._cache.get(cache_key)
         stale_meta: dict[str, Any] | None = None
@@ -136,6 +137,8 @@ class ABSProvider:
                 params.append(("endPeriod", end_period))
             if updated_after:
                 params.append(("updatedAfter", updated_after))
+            if latest_n is not None:
+                params.append(("lastNObservations", str(latest_n)))
             params.append(("format", "csvfilewithlabels"))
 
             url = f"{self.BASE_URL}/data/{dataflow_id}/{key}"

--- a/src/ausecon_mcp/server.py
+++ b/src/ausecon_mcp/server.py
@@ -474,6 +474,8 @@ class AuseconService:
         last_n: int | None = None,
         updated_after: str | None = None,
         include_observation_dimensions: bool = False,
+        *,
+        latest_n: int | None = None,
     ) -> dict:
         validated_dataflow_id = validate_source_token("dataflow_id", dataflow_id)
         validated_key = validate_source_token("key", key)
@@ -493,6 +495,7 @@ class AuseconService:
             end_period=validated_end_period,
             last_n=validated_last_n,
             updated_after=validated_updated_after,
+            latest_n=latest_n,
         )
         if not include_observation_dimensions:
             strip_observation_dimensions(payload)
@@ -705,6 +708,7 @@ class AuseconService:
                 validated_identifier,
                 key=validated_key,
                 last_n=validated_count,
+                latest_n=validated_count,
             )
             return select_latest_observations(payload, count=validated_count)
 

--- a/tests/test_abs_provider.py
+++ b/tests/test_abs_provider.py
@@ -373,6 +373,35 @@ async def test_abs_provider_404_does_not_serve_stale(_isolated_cache_dir) -> Non
 
 
 @pytest.mark.asyncio
+async def test_abs_latest_n_sends_lastnobservations_param() -> None:
+    provider = ABSProvider()
+    csv_payload = (FIXTURES / "abs_cpi_sample.csv").read_text()
+
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get("https://data.api.abs.gov.au/rest/data/CPI/all").mock(
+            return_value=Response(200, text=csv_payload)
+        )
+        await provider.get_data("CPI", key="all", latest_n=3)
+
+    assert "lastNObservations=3" in str(route.calls.last.request.url)
+
+
+@pytest.mark.asyncio
+async def test_abs_latest_n_uses_a_distinct_cache_key() -> None:
+    provider = ABSProvider()
+    csv_payload = (FIXTURES / "abs_cpi_sample.csv").read_text()
+
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get("https://data.api.abs.gov.au/rest/data/CPI/all").mock(
+            return_value=Response(200, text=csv_payload)
+        )
+        await provider.get_data("CPI", key="all", latest_n=3)
+        await provider.get_data("CPI", key="all")  # full-history: must miss cache
+
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
 async def test_abs_provider_sends_identified_user_agent() -> None:
     provider = ABSProvider()
     structure_xml = (FIXTURES / "abs_cpi_structure.xml").read_text()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,15 @@
+from pathlib import Path
+
 import pytest
+import respx
 from fastmcp import Client
+from httpx import Response
 from starlette.middleware.cors import CORSMiddleware
 from starlette.testclient import TestClient
 
 import ausecon_mcp.server as server_module
+from ausecon_mcp.providers.abs import ABSProvider
+from ausecon_mcp.providers.rba import RBAProvider
 from ausecon_mcp.server import AuseconService, build_server
 
 EXPECTED_TOOL_TITLES = {
@@ -117,6 +123,7 @@ class StubABSProvider:
         end_period: str | None = None,
         last_n: int | None = None,
         updated_after: str | None = None,
+        latest_n: int | None = None,
     ) -> dict:
         self.last_get_data_kwargs = {
             "dataflow_id": dataflow_id,
@@ -125,6 +132,7 @@ class StubABSProvider:
             "end_period": end_period,
             "last_n": last_n,
             "updated_after": updated_after,
+            "latest_n": latest_n,
         }
         return {
             "metadata": {"source": "abs", "dataset_id": dataflow_id},
@@ -1918,6 +1926,19 @@ async def test_registered_tools_carry_readonly_and_openworld_annotations() -> No
         assert annotations.destructiveHint is False, f"{tool.name} missing destructiveHint"
         assert annotations.idempotentHint is True, f"{tool.name} missing idempotentHint"
         assert annotations.openWorldHint is True, f"{tool.name} missing openWorldHint"
+
+
+async def test_get_latest_observations_abs_requests_lastnobservations() -> None:
+    csv_payload = (Path(__file__).parent / "fixtures" / "abs_cpi_sample.csv").read_text()
+    service = AuseconService(abs_provider=ABSProvider(), rba_provider=RBAProvider())
+
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get("https://data.api.abs.gov.au/rest/data/CPI/all").mock(
+            return_value=Response(200, text=csv_payload)
+        )
+        await service.get_latest_observations(source="abs", identifier="CPI", count=2)
+
+    assert "lastNObservations=2" in str(route.calls.last.request.url)
 
 
 async def test_registered_tools_expose_top_level_titles_for_hosted_registries() -> None:


### PR DESCRIPTION
Closes **P0.3**: the "latest print" path no longer downloads full ABS history.

- `ABSProvider.get_data` gains `latest_n`, which sends ABS `lastNObservations` and keys the cache distinctly (6-element key) so it can't collide with full-history entries.
- An internal keyword-only `latest_n` on `AuseconService.get_abs_data` is passed only by `get_latest_observations` (ABS branch); the public `get_abs_data` tool is unchanged.

818 tests pass; ruff clean.

⚠️ **Merge after #65 and before the perf PR.** Overlaps with the perf PR on `providers/abs.py` and `server.py`.