### PR TITLE
perf: hot-path pass — concurrent operands, central cache copy, threaded disk I/O, single-flight (P1.7)

### DIFF
--- a/src/ausecon_mcp/cache.py
+++ b/src/ausecon_mcp/cache.py
@@ -80,7 +80,9 @@ class TTLCache:
         entry = _CacheEntry(cached_at=now, expires_at=expires_at, value=value)
         self._entries[key] = entry
         self._write_disk(key, entry)
-        return value
+        # Return a private copy (as get() does) so callers may mutate the result
+        # freely without aliasing the stored entry. The cache is the sole copy owner.
+        return deepcopy(value)
 
     def get_stale(self, key: str) -> dict[str, Any] | None:
         if self._disabled:

--- a/src/ausecon_mcp/cache.py
+++ b/src/ausecon_mcp/cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -82,6 +83,33 @@ class TTLCache:
         self._write_disk(key, entry)
         # Return a private copy (as get() does) so callers may mutate the result
         # freely without aliasing the stored entry. The cache is the sole copy owner.
+        return deepcopy(value)
+
+    async def aget(self, key: str) -> Any | None:
+        if self._disabled:
+            return None
+        now = time()
+        entry = self._entries.get(key)
+        if entry is not None:
+            if entry.expires_at >= now:
+                return deepcopy(entry.value)
+            self._entries.pop(key, None)
+        if not self._disk_enabled:
+            return None
+        disk = await asyncio.to_thread(self._read_disk, key)
+        if disk is None or disk.expires_at < now:
+            return None
+        self._entries[key] = disk
+        return deepcopy(disk.value)
+
+    async def aset(self, key: str, value: Any, ttl_seconds: int | None = None) -> Any:
+        if self._disabled:
+            return value
+        ttl = self._ttl_seconds if ttl_seconds is None else ttl_seconds
+        now = time()
+        entry = _CacheEntry(cached_at=now, expires_at=now + ttl, value=value)
+        self._entries[key] = entry
+        await asyncio.to_thread(self._write_disk, key, entry)
         return deepcopy(value)
 
     def get_stale(self, key: str) -> dict[str, Any] | None:

--- a/src/ausecon_mcp/providers/_single_flight.py
+++ b/src/ausecon_mcp/providers/_single_flight.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+class SingleFlight:
+    """Coalesce concurrent calls that share a key into one in-flight execution.
+
+    The first caller for a key starts ``factory`` as a detached task; concurrent
+    callers for the same key await that same task. The key is cleared once the
+    task settles, so a later (cache-miss) call runs the factory again.
+
+    Callers await the shared task through :func:`asyncio.shield`, so cancelling
+    one caller neither cancels the shared work nor poisons the other coalesced
+    callers — a cancellation affects only the caller that requested it. Because
+    every caller (including the first) awaits the task, its result or exception
+    is always retrieved, avoiding asyncio's "exception was never retrieved" noise.
+    """
+
+    def __init__(self) -> None:
+        self._inflight: dict[str, asyncio.Task[Any]] = {}
+
+    async def run(self, key: str, factory: Callable[[], Awaitable[Any]]) -> Any:
+        task = self._inflight.get(key)
+        if task is not None:
+            return await asyncio.shield(task)
+
+        task = asyncio.ensure_future(factory())
+        # Always retrieve the task's outcome, even if every awaiter is cancelled
+        # before it settles, so an orphaned failure never logs "exception was
+        # never retrieved". (t.exception() raises on a cancelled task, hence the
+        # short-circuit on t.cancelled().)
+        task.add_done_callback(lambda t: t.cancelled() or t.exception())
+        self._inflight[key] = task
+        try:
+            return await asyncio.shield(task)
+        finally:
+            self._inflight.pop(key, None)

--- a/src/ausecon_mcp/providers/abs.py
+++ b/src/ausecon_mcp/providers/abs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from time import perf_counter
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -15,6 +16,7 @@ from ausecon_mcp.parsers.abs_csv import parse_abs_csv
 from ausecon_mcp.parsers.abs_structure import parse_abs_structure
 from ausecon_mcp.providers._http import build_client, resolve_version, utc_now_iso
 from ausecon_mcp.providers._retry import get_with_retries
+from ausecon_mcp.providers._single_flight import SingleFlight
 
 _logger = get_logger("providers.abs")
 
@@ -64,6 +66,7 @@ class ABSProvider:
         self._client = client or build_client()
         self._cache = cache or TTLCache()
         self._ttl_seconds = ttl_seconds
+        self._single_flight = SingleFlight()
 
     async def aclose(self) -> None:
         if self._owns_client:
@@ -126,96 +129,19 @@ class ABSProvider:
         )
         raw_payload = await self._cache.aget(cache_key)
         stale_meta: dict[str, Any] | None = None
-
         if raw_payload is None:
-            params: list[tuple[str, str]] = []
-            if start_period:
-                params.append(("startPeriod", start_period))
-            if end_period:
-                params.append(("endPeriod", end_period))
-            if updated_after:
-                params.append(("updatedAfter", updated_after))
-            params.append(("format", "csvfilewithlabels"))
-
-            url = f"{self.BASE_URL}/data/{dataflow_id}/{key}"
-            _logger.info(
-                "request.start",
-                extra={"source": "abs", "identifier": dataflow_id, "url": url},
+            raw_payload, stale_meta = await self._single_flight.run(
+                cache_key,
+                lambda: self._fetch_data(
+                    dataflow_id,
+                    key,
+                    start_period,
+                    end_period,
+                    updated_after,
+                    cache_key,
+                ),
             )
-            start = perf_counter()
-            try:
-                response = await get_with_retries(
-                    self._client,
-                    url,
-                    params=params,
-                    source="abs",
-                    identifier=dataflow_id,
-                )
-            except AuseconNotFoundError as exc:
-                # The ABS API answers 404 both for unknown dataflows and for valid
-                # dataflows with no observations in the requested window; only the
-                # body distinguishes them. Never fall back to stale data on a 404.
-                if "norecordsfound" in (exc.body or "").lower():
-                    _logger.info(
-                        "request.no_records",
-                        extra={"source": "abs", "identifier": dataflow_id, "url": exc.url},
-                    )
-                    raw_payload = _no_records_payload(
-                        dataflow_id,
-                        url=exc.url,
-                        start_period=start_period,
-                        end_period=end_period,
-                        updated_after=updated_after,
-                    )
-                else:
-                    raise AuseconNotFoundError(
-                        f"ABS request for '{dataflow_id}' failed with HTTP 404: the dataflow "
-                        "appears unknown, renamed, or retired. Check the id with "
-                        "search_datasets or list_catalogue.",
-                        status_code=exc.status_code,
-                        body=exc.body,
-                        url=exc.url,
-                    ) from exc
-            except AuseconUpstreamError:
-                stale = self._cache.get_stale(cache_key)
-                if stale is None:
-                    raise
-                raw_payload = stale["value"]
-                stale_meta = stale
-                _logger.warning(
-                    "request.stale_fallback",
-                    extra={
-                        "source": "abs",
-                        "identifier": dataflow_id,
-                        "cached_at": stale["cached_at"],
-                        "expires_at": stale["expires_at"],
-                    },
-                )
-            else:
-                _logger.info(
-                    "request.success",
-                    extra={
-                        "source": "abs",
-                        "identifier": dataflow_id,
-                        "status_code": response.status_code,
-                        "duration_ms": int((perf_counter() - start) * 1000),
-                        "bytes": len(response.content),
-                    },
-                )
-                try:
-                    raw_payload = parse_abs_csv(response.text)
-                except (KeyError, TypeError, ValueError) as exc:
-                    _logger.error(
-                        "parse.failed",
-                        extra={"source": "abs", "identifier": dataflow_id, "url": url},
-                    )
-                    raise AuseconParseError(
-                        f"Failed to parse ABS data payload for '{dataflow_id}'."
-                    ) from exc
-                raw_payload["metadata"]["retrieval_url"] = str(response.request.url)
-                raw_payload["metadata"]["retrieved_at"] = utc_now_iso()
-                raw_payload["metadata"]["updated_after"] = updated_after
-                raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
+            raw_payload = deepcopy(raw_payload)
 
         payload = filter_payload(raw_payload, last_n=last_n)
         payload["metadata"]["server_version"] = resolve_version()
@@ -224,3 +150,105 @@ class ABSProvider:
             payload["metadata"]["cached_at"] = stale_meta["cached_at"]
             payload["metadata"]["expires_at"] = stale_meta["expires_at"]
         return payload
+
+    async def _fetch_data(
+        self,
+        dataflow_id: str,
+        key: str,
+        start_period: str | None,
+        end_period: str | None,
+        updated_after: str | None,
+        cache_key: str,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        stale_meta: dict[str, Any] | None = None
+        raw_payload = None
+        params: list[tuple[str, str]] = []
+        if start_period:
+            params.append(("startPeriod", start_period))
+        if end_period:
+            params.append(("endPeriod", end_period))
+        if updated_after:
+            params.append(("updatedAfter", updated_after))
+        params.append(("format", "csvfilewithlabels"))
+
+        url = f"{self.BASE_URL}/data/{dataflow_id}/{key}"
+        _logger.info(
+            "request.start",
+            extra={"source": "abs", "identifier": dataflow_id, "url": url},
+        )
+        start = perf_counter()
+        try:
+            response = await get_with_retries(
+                self._client,
+                url,
+                params=params,
+                source="abs",
+                identifier=dataflow_id,
+            )
+        except AuseconNotFoundError as exc:
+            # The ABS API answers 404 both for unknown dataflows and for valid
+            # dataflows with no observations in the requested window; only the
+            # body distinguishes them. Never fall back to stale data on a 404.
+            if "norecordsfound" in (exc.body or "").lower():
+                _logger.info(
+                    "request.no_records",
+                    extra={"source": "abs", "identifier": dataflow_id, "url": exc.url},
+                )
+                raw_payload = _no_records_payload(
+                    dataflow_id,
+                    url=exc.url,
+                    start_period=start_period,
+                    end_period=end_period,
+                    updated_after=updated_after,
+                )
+            else:
+                raise AuseconNotFoundError(
+                    f"ABS request for '{dataflow_id}' failed with HTTP 404: the dataflow "
+                    "appears unknown, renamed, or retired. Check the id with "
+                    "search_datasets or list_catalogue.",
+                    status_code=exc.status_code,
+                    body=exc.body,
+                    url=exc.url,
+                ) from exc
+        except AuseconUpstreamError:
+            stale = self._cache.get_stale(cache_key)
+            if stale is None:
+                raise
+            raw_payload = stale["value"]
+            stale_meta = stale
+            _logger.warning(
+                "request.stale_fallback",
+                extra={
+                    "source": "abs",
+                    "identifier": dataflow_id,
+                    "cached_at": stale["cached_at"],
+                    "expires_at": stale["expires_at"],
+                },
+            )
+        else:
+            _logger.info(
+                "request.success",
+                extra={
+                    "source": "abs",
+                    "identifier": dataflow_id,
+                    "status_code": response.status_code,
+                    "duration_ms": int((perf_counter() - start) * 1000),
+                    "bytes": len(response.content),
+                },
+            )
+            try:
+                raw_payload = parse_abs_csv(response.text)
+            except (KeyError, TypeError, ValueError) as exc:
+                _logger.error(
+                    "parse.failed",
+                    extra={"source": "abs", "identifier": dataflow_id, "url": url},
+                )
+                raise AuseconParseError(
+                    f"Failed to parse ABS data payload for '{dataflow_id}'."
+                ) from exc
+            raw_payload["metadata"]["retrieval_url"] = str(response.request.url)
+            raw_payload["metadata"]["retrieved_at"] = utc_now_iso()
+            raw_payload["metadata"]["updated_after"] = updated_after
+            raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
+
+        return raw_payload, stale_meta

--- a/src/ausecon_mcp/providers/abs.py
+++ b/src/ausecon_mcp/providers/abs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from copy import deepcopy
 from time import perf_counter
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -218,7 +217,7 @@ class ABSProvider:
                 raw_payload["metadata"]["updated_after"] = updated_after
                 raw_payload = self._cache.set(cache_key, raw_payload, self._ttl_seconds)
 
-        payload = filter_payload(deepcopy(raw_payload), last_n=last_n)
+        payload = filter_payload(raw_payload, last_n=last_n)
         payload["metadata"]["server_version"] = resolve_version()
         if stale_meta is not None:
             payload["metadata"]["stale"] = True

--- a/src/ausecon_mcp/providers/abs.py
+++ b/src/ausecon_mcp/providers/abs.py
@@ -71,7 +71,7 @@ class ABSProvider:
 
     async def get_dataset_structure(self, dataflow_id: str) -> dict[str, Any]:
         cache_key = f"abs-structure:{dataflow_id}"
-        cached = self._cache.get(cache_key)
+        cached = await self._cache.aget(cache_key)
         if cached is not None:
             _logger.debug("cache.hit", extra={"source": "abs", "identifier": dataflow_id})
             return cached
@@ -109,7 +109,7 @@ class ABSProvider:
             raise AuseconParseError(
                 f"Failed to parse ABS structure payload for '{dataflow_id}'."
             ) from exc
-        return self._cache.set(cache_key, parsed, self._ttl_seconds)
+        return await self._cache.aset(cache_key, parsed, self._ttl_seconds)
 
     async def get_data(
         self,
@@ -124,7 +124,7 @@ class ABSProvider:
         cache_key = "abs-data:" + json.dumps(
             [dataflow_id, key, start_period, end_period, updated_after]
         )
-        raw_payload = self._cache.get(cache_key)
+        raw_payload = await self._cache.aget(cache_key)
         stale_meta: dict[str, Any] | None = None
 
         if raw_payload is None:
@@ -215,7 +215,7 @@ class ABSProvider:
                 raw_payload["metadata"]["retrieval_url"] = str(response.request.url)
                 raw_payload["metadata"]["retrieved_at"] = utc_now_iso()
                 raw_payload["metadata"]["updated_after"] = updated_after
-                raw_payload = self._cache.set(cache_key, raw_payload, self._ttl_seconds)
+                raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
 
         payload = filter_payload(raw_payload, last_n=last_n)
         payload["metadata"]["server_version"] = resolve_version()

--- a/src/ausecon_mcp/providers/apra.py
+++ b/src/ausecon_mcp/providers/apra.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from copy import deepcopy
 from html.parser import HTMLParser
 from importlib import resources
 from time import perf_counter
@@ -19,6 +20,7 @@ from ausecon_mcp.logging import get_logger
 from ausecon_mcp.parsers.apra_xlsx import parse_apra_xlsx
 from ausecon_mcp.providers._http import build_client, resolve_version, utc_now_iso
 from ausecon_mcp.providers._retry import get_with_retries
+from ausecon_mcp.providers._single_flight import SingleFlight
 
 _logger = get_logger("providers.apra")
 _TRUSTED_APRA_DOWNLOAD_HOSTS = {"apra.gov.au", "www.apra.gov.au"}
@@ -38,6 +40,7 @@ class APRAProvider:
         self._cache = cache or TTLCache()
         self._ttl_seconds = ttl_seconds
         self._catalogue = catalogue or APRA_CATALOGUE
+        self._single_flight = SingleFlight()
 
     async def aclose(self) -> None:
         if self._owns_client:
@@ -65,31 +68,12 @@ class APRAProvider:
         cache_key = _cache_key(publication_id, table_id)
         raw_payload = await self._cache.aget(cache_key)
         stale_meta: dict[str, Any] | None = None
-
         if raw_payload is None:
-            try:
-                raw_payload = await self._fetch_and_parse(
-                    publication_id,
-                    entry,
-                    table_id=table_id,
-                )
-            except AuseconUpstreamError:
-                stale = self._cache.get_stale(cache_key)
-                if stale is None:
-                    raise
-                raw_payload = stale["value"]
-                stale_meta = stale
-                _logger.warning(
-                    "request.stale_fallback",
-                    extra={
-                        "source": "apra",
-                        "identifier": publication_id,
-                        "cached_at": stale["cached_at"],
-                        "expires_at": stale["expires_at"],
-                    },
-                )
-            else:
-                raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
+            raw_payload, stale_meta = await self._single_flight.run(
+                cache_key,
+                lambda: self._fetch_publication(publication_id, entry, table_id, cache_key),
+            )
+            raw_payload = deepcopy(raw_payload)
 
         payload = raw_payload
         if table_id is not None:
@@ -111,6 +95,40 @@ class APRAProvider:
             payload["metadata"]["cached_at"] = stale_meta["cached_at"]
             payload["metadata"]["expires_at"] = stale_meta["expires_at"]
         return payload
+
+    async def _fetch_publication(
+        self,
+        publication_id: str,
+        entry: dict[str, Any],
+        table_id: str | None,
+        cache_key: str,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        stale_meta: dict[str, Any] | None = None
+        try:
+            raw_payload = await self._fetch_and_parse(
+                publication_id,
+                entry,
+                table_id=table_id,
+            )
+        except AuseconUpstreamError:
+            stale = self._cache.get_stale(cache_key)
+            if stale is None:
+                raise
+            raw_payload = stale["value"]
+            stale_meta = stale
+            _logger.warning(
+                "request.stale_fallback",
+                extra={
+                    "source": "apra",
+                    "identifier": publication_id,
+                    "cached_at": stale["cached_at"],
+                    "expires_at": stale["expires_at"],
+                },
+            )
+        else:
+            raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
+
+        return raw_payload, stale_meta
 
     async def _fetch_and_parse(
         self,

--- a/src/ausecon_mcp/providers/apra.py
+++ b/src/ausecon_mcp/providers/apra.py
@@ -63,7 +63,7 @@ class APRAProvider:
             )
 
         cache_key = _cache_key(publication_id, table_id)
-        raw_payload = self._cache.get(cache_key)
+        raw_payload = await self._cache.aget(cache_key)
         stale_meta: dict[str, Any] | None = None
 
         if raw_payload is None:
@@ -89,7 +89,7 @@ class APRAProvider:
                     },
                 )
             else:
-                raw_payload = self._cache.set(cache_key, raw_payload, self._ttl_seconds)
+                raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
 
         payload = raw_payload
         if table_id is not None:

--- a/src/ausecon_mcp/providers/apra.py
+++ b/src/ausecon_mcp/providers/apra.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from copy import deepcopy
 from html.parser import HTMLParser
 from importlib import resources
 from time import perf_counter
@@ -92,7 +91,7 @@ class APRAProvider:
             else:
                 raw_payload = self._cache.set(cache_key, raw_payload, self._ttl_seconds)
 
-        payload = deepcopy(raw_payload)
+        payload = raw_payload
         if table_id is not None:
             payload["metadata"]["frequency"] = entry["tables"][table_id].get(
                 "frequency",

--- a/src/ausecon_mcp/providers/rba.py
+++ b/src/ausecon_mcp/providers/rba.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from time import perf_counter
 from typing import Any
 
@@ -128,7 +127,7 @@ class RBAProvider:
                 raw_payload = self._cache.set(cache_key, raw_payload, self._ttl_seconds)
 
         payload = filter_payload(
-            deepcopy(raw_payload),
+            raw_payload,
             series_ids=series_ids,
             start_date=start_date,
             end_date=end_date,

--- a/src/ausecon_mcp/providers/rba.py
+++ b/src/ausecon_mcp/providers/rba.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from time import perf_counter
 from typing import Any
 
@@ -13,6 +14,7 @@ from ausecon_mcp.logging import get_logger
 from ausecon_mcp.parsers.rba_csv import parse_rba_csv
 from ausecon_mcp.providers._http import build_client, resolve_version, utc_now_iso
 from ausecon_mcp.providers._retry import get_with_retries
+from ausecon_mcp.providers._single_flight import SingleFlight
 
 _logger = get_logger("providers.rba")
 
@@ -30,6 +32,7 @@ class RBAProvider:
         self._client = client or build_client()
         self._cache = cache or TTLCache()
         self._ttl_seconds = ttl_seconds
+        self._single_flight = SingleFlight()
 
     async def aclose(self) -> None:
         if self._owns_client:
@@ -69,62 +72,12 @@ class RBAProvider:
         cache_key = f"rba-table:{table_id}"
         raw_payload = await self._cache.aget(cache_key)
         stale_meta: dict[str, Any] | None = None
-
         if raw_payload is None:
-            filename = csv_path or f"{table_id}-data.csv"
-            url = f"{self.BASE_URL}/{filename}"
-            _logger.info(
-                "request.start",
-                extra={"source": "rba", "identifier": table_id, "url": url},
+            raw_payload, stale_meta = await self._single_flight.run(
+                cache_key,
+                lambda: self._fetch_table(table_id, csv_path, cache_key),
             )
-            start = perf_counter()
-            try:
-                response = await get_with_retries(
-                    self._client,
-                    url,
-                    params=None,
-                    source="rba",
-                    identifier=table_id,
-                )
-            except AuseconUpstreamError:
-                stale = self._cache.get_stale(cache_key)
-                if stale is None:
-                    raise
-                raw_payload = stale["value"]
-                stale_meta = stale
-                _logger.warning(
-                    "request.stale_fallback",
-                    extra={
-                        "source": "rba",
-                        "identifier": table_id,
-                        "cached_at": stale["cached_at"],
-                        "expires_at": stale["expires_at"],
-                    },
-                )
-            else:
-                _logger.info(
-                    "request.success",
-                    extra={
-                        "source": "rba",
-                        "identifier": table_id,
-                        "status_code": response.status_code,
-                        "duration_ms": int((perf_counter() - start) * 1000),
-                        "bytes": len(response.content),
-                    },
-                )
-                try:
-                    raw_payload = parse_rba_csv(response.text, table_id=table_id)
-                except (IndexError, KeyError, TypeError, ValueError) as exc:
-                    _logger.error(
-                        "parse.failed",
-                        extra={"source": "rba", "identifier": table_id, "url": url},
-                    )
-                    raise AuseconParseError(
-                        f"Failed to parse RBA table payload for '{table_id}'."
-                    ) from exc
-                raw_payload["metadata"]["retrieval_url"] = str(response.request.url)
-                raw_payload["metadata"]["retrieved_at"] = utc_now_iso()
-                raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
+            raw_payload = deepcopy(raw_payload)
 
         payload = filter_payload(
             raw_payload,
@@ -139,3 +92,68 @@ class RBAProvider:
             payload["metadata"]["cached_at"] = stale_meta["cached_at"]
             payload["metadata"]["expires_at"] = stale_meta["expires_at"]
         return payload
+
+    async def _fetch_table(
+        self,
+        table_id: str,
+        csv_path: str | None,
+        cache_key: str,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        stale_meta: dict[str, Any] | None = None
+        raw_payload = None
+        filename = csv_path or f"{table_id}-data.csv"
+        url = f"{self.BASE_URL}/{filename}"
+        _logger.info(
+            "request.start",
+            extra={"source": "rba", "identifier": table_id, "url": url},
+        )
+        start = perf_counter()
+        try:
+            response = await get_with_retries(
+                self._client,
+                url,
+                params=None,
+                source="rba",
+                identifier=table_id,
+            )
+        except AuseconUpstreamError:
+            stale = self._cache.get_stale(cache_key)
+            if stale is None:
+                raise
+            raw_payload = stale["value"]
+            stale_meta = stale
+            _logger.warning(
+                "request.stale_fallback",
+                extra={
+                    "source": "rba",
+                    "identifier": table_id,
+                    "cached_at": stale["cached_at"],
+                    "expires_at": stale["expires_at"],
+                },
+            )
+        else:
+            _logger.info(
+                "request.success",
+                extra={
+                    "source": "rba",
+                    "identifier": table_id,
+                    "status_code": response.status_code,
+                    "duration_ms": int((perf_counter() - start) * 1000),
+                    "bytes": len(response.content),
+                },
+            )
+            try:
+                raw_payload = parse_rba_csv(response.text, table_id=table_id)
+            except (IndexError, KeyError, TypeError, ValueError) as exc:
+                _logger.error(
+                    "parse.failed",
+                    extra={"source": "rba", "identifier": table_id, "url": url},
+                )
+                raise AuseconParseError(
+                    f"Failed to parse RBA table payload for '{table_id}'."
+                ) from exc
+            raw_payload["metadata"]["retrieval_url"] = str(response.request.url)
+            raw_payload["metadata"]["retrieved_at"] = utc_now_iso()
+            raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
+
+        return raw_payload, stale_meta

--- a/src/ausecon_mcp/providers/rba.py
+++ b/src/ausecon_mcp/providers/rba.py
@@ -67,7 +67,7 @@ class RBAProvider:
         csv_path: str | None = None,
     ) -> dict[str, Any]:
         cache_key = f"rba-table:{table_id}"
-        raw_payload = self._cache.get(cache_key)
+        raw_payload = await self._cache.aget(cache_key)
         stale_meta: dict[str, Any] | None = None
 
         if raw_payload is None:
@@ -124,7 +124,7 @@ class RBAProvider:
                     ) from exc
                 raw_payload["metadata"]["retrieval_url"] = str(response.request.url)
                 raw_payload["metadata"]["retrieved_at"] = utc_now_iso()
-                raw_payload = self._cache.set(cache_key, raw_payload, self._ttl_seconds)
+                raw_payload = await self._cache.aset(cache_key, raw_payload, self._ttl_seconds)
 
         payload = filter_payload(
             raw_payload,

--- a/src/ausecon_mcp/server.py
+++ b/src/ausecon_mcp/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Annotated, Any, Literal
 
@@ -660,19 +661,30 @@ class AuseconService:
         validated_concept = require_non_empty("concept", concept)
         validated_last_n = validate_positive_int("last_n", last_n)
         validate_derived_bounds(validated_concept, start=start, end=end)
-        operands: dict[str, dict] = {}
-        for operand in get_operand_specs(validated_concept):
-            operand_start, operand_end = operand_request_bounds(
+        operand_specs = list(get_operand_specs(validated_concept))
+        operand_bounds = {
+            operand.name: operand_request_bounds(
                 validated_concept,
                 operand.name,
                 start=start,
                 end=end,
             )
-            operands[operand.name] = await self.get_economic_series(
-                operand.concept,
-                start=operand_start,
-                end=operand_end,
+            for operand in operand_specs
+        }
+        fetched = await asyncio.gather(
+            *(
+                self.get_economic_series(
+                    operand.concept,
+                    start=operand_bounds[operand.name][0],
+                    end=operand_bounds[operand.name][1],
+                )
+                for operand in operand_specs
             )
+        )
+        operands = {
+            operand.name: payload
+            for operand, payload in zip(operand_specs, fetched, strict=True)
+        }
         return derive_series(
             validated_concept,
             operands,

--- a/tests/test_abs_provider.py
+++ b/tests/test_abs_provider.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from pathlib import Path
 
@@ -387,3 +388,21 @@ async def test_abs_provider_sends_identified_user_agent() -> None:
     ua = route.calls.last.request.headers["user-agent"]
     assert ua.startswith("ausecon-mcp-server/")
     assert "github.com/AnthonyPuggs/ausecon-mcp-server" in ua
+
+
+@pytest.mark.asyncio
+async def test_abs_concurrent_identical_calls_hit_upstream_once() -> None:
+    provider = ABSProvider()
+    csv_payload = (FIXTURES / "abs_cpi_sample.csv").read_text()
+
+    with respx.mock(assert_all_called=True) as router:
+        route = router.get("https://data.api.abs.gov.au/rest/data/CPI/all").mock(
+            return_value=Response(200, text=csv_payload)
+        )
+        await asyncio.gather(
+            provider.get_data("CPI", key="all"),
+            provider.get_data("CPI", key="all"),
+            provider.get_data("CPI", key="all"),
+        )
+
+    assert route.call_count == 1

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -284,6 +284,26 @@ def test_unlink_ignores_paths_outside_trusted_cache_root(tmp_path) -> None:
     assert outside.exists()
 
 
+async def test_async_round_trip_matches_sync(_isolated_cache_dir: Path) -> None:
+    cache = TTLCache(ttl_seconds=60)
+
+    returned = await cache.aset("k", {"v": 1})
+    returned["v"] = 999  # mutating the return must not poison the cache
+
+    assert await cache.aget("k") == {"v": 1}
+    assert await cache.aget("missing") is None
+
+
+async def test_aget_promotes_a_warm_disk_entry(_isolated_cache_dir: Path) -> None:
+    # Exercises the threaded disk path: aset writes to disk, then a fresh cache
+    # with an empty in-memory layer must read it back through aget.
+    first = TTLCache(ttl_seconds=60)
+    await first.aset("k", {"v": 1})
+
+    second = TTLCache(ttl_seconds=60)
+    assert await second.aget("k") == {"v": 1}
+
+
 @pytest.mark.parametrize("ttl", [0, -1])
 def test_zero_or_negative_ttl_expires_immediately(ttl) -> None:
     cache = TTLCache(ttl_seconds=ttl)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -290,3 +290,13 @@ def test_zero_or_negative_ttl_expires_immediately(ttl) -> None:
     cache.set("k", {"v": 1})
 
     assert cache.get("k") is None
+
+
+def test_set_returns_a_private_copy() -> None:
+    cache = TTLCache(ttl_seconds=60)
+    payload = {"series": [{"id": "a"}]}
+
+    returned = cache.set("k", payload)
+    returned["series"].append({"id": "mutated"})
+
+    assert cache.get("k") == {"series": [{"id": "a"}]}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from fastmcp import Client
 from starlette.middleware.cors import CORSMiddleware
@@ -2036,3 +2038,29 @@ async def test_all_registered_tools_expose_output_schema() -> None:
         output_schema = tool.outputSchema
         assert output_schema["type"] == "object", f"{tool.name} missing object output schema"
         assert output_schema.get("description") or output_schema.get("title")
+
+
+@pytest.mark.asyncio
+async def test_get_derived_series_fetches_operands_concurrently(monkeypatch) -> None:
+    service = AuseconService()
+    active = 0
+    max_active = 0
+
+    async def fake_get_economic_series(concept, *, start=None, end=None, **kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return {
+            "metadata": {"source": "rba", "dataset_id": concept},
+            "series": [{"series_id": concept}],
+            "observations": [],
+        }
+
+    monkeypatch.setattr(service, "get_economic_series", fake_get_economic_series)
+
+    # misery_index has two independent operands (unemployment_rate, monthly_inflation)
+    await service.get_derived_series("misery_index")
+
+    assert max_active == 2

--- a/tests/test_single_flight.py
+++ b/tests/test_single_flight.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ausecon_mcp.providers._single_flight import SingleFlight
+
+
+async def test_single_flight_runs_factory_once_for_concurrent_keys() -> None:
+    flight = SingleFlight()
+    calls = 0
+
+    async def factory():
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return calls
+
+    results = await asyncio.gather(
+        flight.run("k", factory),
+        flight.run("k", factory),
+        flight.run("k", factory),
+    )
+
+    assert calls == 1
+    assert results == [1, 1, 1]
+
+
+async def test_single_flight_propagates_exceptions_to_all_callers() -> None:
+    flight = SingleFlight()
+
+    async def factory():
+        await asyncio.sleep(0.01)
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await asyncio.gather(flight.run("k", factory), flight.run("k", factory))
+
+
+async def test_single_flight_refetches_after_the_first_call_settles() -> None:
+    flight = SingleFlight()
+    calls = 0
+
+    async def factory():
+        nonlocal calls
+        calls += 1
+        return calls
+
+    assert await flight.run("k", factory) == 1
+    # The key is cleared once settled, so a later call runs the factory again.
+    assert await flight.run("k", factory) == 2
+    assert calls == 2
+
+
+async def test_single_flight_cancelling_one_caller_does_not_poison_others() -> None:
+    flight = SingleFlight()
+    calls = 0
+
+    async def factory():
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return "ok"
+
+    first = asyncio.ensure_future(flight.run("k", factory))
+    second = asyncio.ensure_future(flight.run("k", factory))
+    await asyncio.sleep(0.01)  # let both register against the same in-flight task
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    # The shared work survives the first caller's cancellation, and the second
+    # caller still receives the real result from the single factory run.
+    assert await second == "ok"
+    assert calls == 1


### PR DESCRIPTION
Closes **P1.7** — the hot-path performance pass, in four commits:

1. Fetch derived operands concurrently (`asyncio.gather`).
2. Centralise payload copying in `cache.set` (drop redundant per-provider `deepcopy`; hot path 2→1 copies).
3. Thread cache disk I/O off the event loop (`aget`/`aset` via `asyncio.to_thread`).
4. Single-flight: coalesce concurrent identical upstream fetches (detached task + `asyncio.shield`, so one caller's cancellation can't poison coalesced waiters).

824 tests pass; ruff clean.

⚠️ **Merge LAST (after #65 and #66).** Conflicts with #66 on `providers/abs.py` and `server.py`: when resolving, the `_fetch_data` factory introduced here must carry #66's `latest_n` parameter, the `lastNObservations` append, and the 6-element cache key.