### PR TITLE
chore: prepare v1.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-06-15
+
+### Added
+
+- `metadata.derived` now carries an explicit `alignment_method` — one of `locf`,
+  `exact_month`, `period_intersection`, or `year_ended_lag` — declared on all 16
+  derived concepts, so consumers can tell how each indicator's operands were aligned
+  (e.g. last-observation-carried-forward, which can bias spreads and ratios around
+  turning points).
+
+### Changed
+
+- Real-rate concept descriptions (`real_cash_rate`, `real_10y_bond_yield`,
+  `real_bank_bill_rate`, `real_business_lending_rate`, `real_mortgage_rate`) now state
+  explicitly that they are ex-post real rates (nominal less realised year-ended CPI
+  inflation), not the ex-ante Fisher definition.
+- `get_latest_observations` for ABS now requests only the most recent observations
+  upstream via SDMX `lastNObservations`, keyed distinctly in the cache, instead of
+  downloading the full dataflow and truncating client-side. The expert `get_abs_data`
+  tool is unchanged.
+- Internal request hot-path performance: derived-operand fetches now run concurrently
+  (`asyncio.gather`); payload copying is centralised in the cache (the request hot path
+  drops from two deep copies to one); cache disk I/O is offloaded off the event loop;
+  and concurrent identical upstream fetches are coalesced with a single-flight helper so
+  a burst of duplicate requests hits the source only once.
+- The response schema's `derived_metadata` gains a required `alignment_method` field.
+  This is additive — existing fields and tool signatures are unchanged.
+
+### Fixed
+
+- `real_business_lending_rate` now aligns its lending-rate and inflation operands by
+  `(year, month)`, so the RBA monthly end-of-month series and the ABS monthly CPI series
+  intersect correctly instead of yielding an empty result.
+
 ## [1.10.0] - 2026-06-13
 
 ### Added
@@ -644,7 +678,8 @@ Initial public release.
 - Initial curated catalogues for ABS and RBA, plus a four-concept
   `CURATED_SERIES` semantic shortcut map.
 
-[Unreleased]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.7.1...v1.8.0

--- a/docs-site/src/content/docs/getting-started/index.md
+++ b/docs-site/src/content/docs/getting-started/index.md
@@ -50,5 +50,5 @@ get_economic_series(
 
 Retrieval responses include `metadata`, `series`, and `observations`. Semantic retrievals also
 include `metadata.semantic`, recording the resolved source target and normalised date bounds.
-Derived retrievals include `metadata.derived`, recording the formula, operands, units, and
-alignment frequency.
+Derived retrievals include `metadata.derived`, recording the formula, operands, units, alignment
+frequency, and alignment method.

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -32,7 +32,7 @@ retrieval, and stable JSON outputs without turning the server into a general eco
 
 ## Current status
 
-Version `1.10.0` is the current release line. The server remains intentionally selective: it covers
+Version `1.11.0` is the current release line. The server remains intentionally selective: it covers
 the main analyst workflows, supports stdio plus hosted Streamable HTTP, and does not aim to mirror
 every ABS, RBA, or APRA release.
 

--- a/docs-site/src/content/docs/maintainers/roadmap.md
+++ b/docs-site/src/content/docs/maintainers/roadmap.md
@@ -3,7 +3,7 @@ title: Roadmap
 description: Release priorities for AusEcon MCP.
 ---
 
-The current v1.10.0 release line includes stable stdio, hosted Streamable HTTP through
+The current v1.11.0 release line includes stable stdio, hosted Streamable HTTP through
 Render/Smithery, curated ABS/RBA/APRA retrieval, release-event awareness, convenience observation
 tools, generated documentation, and docs-site Vercel Analytics plus Speed Insights.
 

--- a/docs/response-schema.md
+++ b/docs/response-schema.md
@@ -43,8 +43,9 @@ source-native resolved bounds, and the ABS/RBA/APRA target used for retrieval. A
 targets include `apra_table_id` and `apra_series_ids`. Raw `get_abs_data`, `get_rba_table`, and
 `get_apra_data` responses do not include this field.
 
-`derived` records the formula, operands, source concepts, alignment frequency, output units,
-requested and resolved bounds, and dropped-observation counts for transparent derived indicators.
+`derived` records the formula, operands, source concepts, alignment frequency, alignment method,
+output units, requested and resolved bounds, and dropped-observation counts for transparent derived
+indicators.
 
 ## Series And Observations
 

--- a/docs/smithery-deployment.md
+++ b/docs/smithery-deployment.md
@@ -10,15 +10,15 @@ Before connecting Smithery, confirm the release state is consistent:
 
 ```bash
 git status --short --branch
-git ls-remote origin refs/heads/main refs/tags/v1.10.0
+git ls-remote origin refs/heads/main refs/tags/v1.11.0
 python3 -m pip index versions ausecon-mcp-server
 ```
 
-Expected state for the v1.10.0 Smithery release:
+Expected state for the v1.11.0 Smithery release:
 
-- `main` and `v1.10.0` point at the same published release commit.
-- PyPI lists `ausecon-mcp-server (1.10.0)`.
-- `server.json` and `CHANGELOG.md` both refer to `1.10.0`.
+- `main` and `v1.11.0` point at the same published release commit.
+- PyPI lists `ausecon-mcp-server (1.11.0)`.
+- `server.json` and `CHANGELOG.md` both refer to `1.11.0`.
 - `smithery.yaml` declares `runtime: "container"` and `startCommand.type: "http"`.
 - `Dockerfile.smithery` builds the local wheel and runs `ausecon-mcp-http`.
 
@@ -48,7 +48,7 @@ startCommand:
   type: "http"
 ```
 
-Do not add `configSchema` or `exampleConfig` for v1.10.0. The server does not
+Do not add `configSchema` or `exampleConfig` for v1.11.0. The server does not
 need user secrets or per-session configuration because every exposed tool reads
 public ABS, RBA, and APRA data.
 
@@ -65,8 +65,8 @@ After the first Smithery build:
   `get_latest_observations`, `get_top_observations`, `describe_dataset`, and
   `list_release_events`.
 - Check response metadata from a live retrieval. `metadata.server_version`
-  should report `1.10.0`; if it reports a fallback value, configure Smithery to
-  pass `AUSECON_VERSION=1.10.0` as a Docker build argument if the platform
+  should report `1.11.0`; if it reports a fallback value, configure Smithery to
+  pass `AUSECON_VERSION=1.11.0` as a Docker build argument if the platform
   supports build args.
 
 Use the Smithery Playground for smoke tests:

--- a/server.json
+++ b/server.json
@@ -3,13 +3,13 @@
   "name": "io.github.AnthonyPuggs/ausecon-mcp-server",
   "title": "Australian Economic Data (ABS, RBA & APRA)",
   "description": "Australian economic data from the ABS, RBA, and APRA: CPI, GDP, cash rate, labour force, banking statistics, among others.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "packages": [
     {
       "identifier": "ausecon-mcp-server",
       "registryType": "pypi",
       "runtimeHint": "uvx",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_repository_hygiene.py
+++ b/tests/test_repository_hygiene.py
@@ -211,9 +211,9 @@ def test_readme_is_rich_landing_page_for_current_release_state() -> None:
 
     assert '<img src="assets/banner.svg"' in readme_text
     assert "Australian economic data is authoritative but awkward to reach" in readme_text
-    assert "Version `1.10.0` is the current release line." in docs_home_text
-    assert "Version `1.9.0` is the current release line." not in readme_text
-    assert "Version `1.9.0` is the current release line." not in docs_home_text
+    assert "Version `1.11.0` is the current release line." in docs_home_text
+    assert "Version `1.10.0` is the current release line." not in readme_text
+    assert "Version `1.10.0` is the current release line." not in docs_home_text
 
     assert "<b>14</b>" in readme_text
     assert "read-only tools" in readme_text
@@ -315,7 +315,7 @@ def test_post_v11_roadmap_is_documented_and_contract_preserving() -> None:
     assert "v1.5" in docs_roadmap_text
     assert "v1.6" in docs_roadmap_text
     assert "v2.0" in docs_roadmap_text
-    assert "current v1.10.0 release line" in docs_roadmap_text
+    assert "current v1.11.0 release line" in docs_roadmap_text
     assert "APRA" in docs_roadmap_text
     assert "APRA source-native foundation" in docs_roadmap_text
     assert "{metadata, series, observations}" in docs_roadmap_text
@@ -546,20 +546,23 @@ def test_codeql_and_dependabot_are_configured_for_visible_security_automation() 
     assert "advanced CodeQL workflow" in releasing_text
 
 
-def test_changelog_promotes_v1100_and_keeps_fresh_unreleased_section() -> None:
+def test_changelog_promotes_v1110_and_keeps_fresh_unreleased_section() -> None:
     changelog_text = CHANGELOG.read_text(encoding="utf-8")
     unreleased_index = changelog_text.index("## [Unreleased]")
-    v1100_index = changelog_text.index("## [1.10.0] - 2026-06-13")
+    v1110_index = changelog_text.index("## [1.11.0] - 2026-06-15")
 
-    assert unreleased_index < v1100_index
-    unreleased_section = changelog_text[unreleased_index:v1100_index]
-    v1100_section = changelog_text[v1100_index : changelog_text.index("## [1.9.0]")]
+    assert unreleased_index < v1110_index
+    unreleased_section = changelog_text[unreleased_index:v1110_index]
+    v1110_section = changelog_text[v1110_index : changelog_text.index("## [1.10.0]")]
 
-    assert "terms_of_trade" not in unreleased_section
-    assert "terms_of_trade" in v1100_section
-    assert "misery_index" in v1100_section
+    assert "alignment_method" not in unreleased_section
+    assert "alignment_method" in v1110_section
+    assert "lastNObservations" in v1110_section
     assert (
-        "[Unreleased]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.10.0...HEAD"
+        "[Unreleased]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.11.0...HEAD"
+    ) in changelog_text
+    assert (
+        "[1.11.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.10.0...v1.11.0"
     ) in changelog_text
     assert (
         "[1.10.0]: https://github.com/AnthonyPuggs/ausecon-mcp-server/compare/v1.9.0...v1.10.0"
@@ -581,12 +584,12 @@ def test_changelog_promotes_v1100_and_keeps_fresh_unreleased_section() -> None:
 def test_smithery_deployment_docs_match_current_release_state() -> None:
     smithery_text = (ROOT / "docs" / "smithery-deployment.md").read_text(encoding="utf-8")
 
-    assert "v1.10.0" in smithery_text
-    assert "1.10.0" in smithery_text
+    assert "v1.11.0" in smithery_text
+    assert "1.11.0" in smithery_text
     assert "fourteen tools" in smithery_text
     assert "get_latest_observations" in smithery_text
     assert "list_release_events" in smithery_text
-    assert "v1.9.0" not in smithery_text
+    assert "v1.10.0" not in smithery_text
 
 
 def test_readme_release_instructions_match_tag_derived_versioning() -> None:


### PR DESCRIPTION
Release-preparation for **v1.11.0**. Merge this, then tag `v1.11.0` on `main` to trigger the PyPI publish.

## What this changes

- **CHANGELOG.md**: promotes `[Unreleased]` into `## [1.11.0] - 2026-06-15` (Added: `alignment_method`; Changed: ex-post real-rate descriptions, ABS `lastNObservations` latest path, hot-path performance pass, the additive `alignment_method` schema field; Fixed: `real_business_lending_rate` month alignment) and adds the `v1.10.0...v1.11.0` link reference.
- **server.json**: `version` → `1.11.0` (both the server and the pypi package entry).
- **docs**: `index.mdx` and `roadmap.md` current-release line → `1.11.0`; `smithery-deployment.md` runbook references → `1.11.0`; `response-schema.md` and `getting-started` now mention `alignment_method` in `metadata.derived`.
- **tests/test_repository_hygiene.py**: version-consistency assertions repinned to the v1.11.0 release line.

No package code changes — this is metadata/docs/tests only. Full suite (834) and ruff pass.

## After merge

```
git checkout main && git pull
git tag v1.11.0 && git push origin v1.11.0
```

hatch-vcs derives the package version from the tag.