### PR TITLE
feat: surface derived descriptions and nudge off heavy unfiltered pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Derived series now expose their concept `description` in
+  `metadata.derived.description`, so the curated caveats (e.g. that real rates are
+  ex-post, not ex-ante Fisher) reach MCP clients instead of living only in source.
+  The response schema's `derived_metadata` gains a required `description` field
+  (additive; existing fields and tool signatures unchanged).
+- `get_latest_observations` and `get_top_observations` now append a plain-English
+  `metadata.warnings` nudge when an unfiltered curated dataset returns many series
+  (e.g. all of `ADI_QUARTERLY_PERFORMANCE`), pointing callers at the lean
+  `get_economic_series(concept=...)` path and the `series_ids` filter. The nudge is
+  suppressed once a result is narrowed, and is appended without clobbering existing
+  source warnings such as APRA framework breaks.
+
 ## [1.11.0] - 2026-06-15
 
 ### Added

--- a/schemas/response.schema.json
+++ b/schemas/response.schema.json
@@ -372,6 +372,7 @@
       "type": "object",
       "required": [
         "concept",
+        "description",
         "formula",
         "operands",
         "source_concepts",
@@ -385,6 +386,9 @@
       "additionalProperties": false,
       "properties": {
         "concept": {
+          "type": "string"
+        },
+        "description": {
           "type": "string"
         },
         "formula": {

--- a/src/ausecon_mcp/catalogue/resolver.py
+++ b/src/ausecon_mcp/catalogue/resolver.py
@@ -310,6 +310,20 @@ CURATED_SHORTCUTS: dict[str, dict[str, Any]] = {
 }
 
 
+def concepts_for_dataset(source: str, dataset_id: str) -> list[str]:
+    """Curated concept names whose shortcut targets this ``(source, dataset_id)``.
+
+    Used to steer callers from a broad source-native pull (e.g. every series in
+    ``ADI_QUARTERLY_PERFORMANCE``) toward the lean ``get_economic_series`` concept
+    that resolves a single curated variant.
+    """
+    return sorted(
+        name
+        for name, shortcut in CURATED_SHORTCUTS.items()
+        if shortcut["source"] == source and shortcut["dataset_id"] == dataset_id
+    )
+
+
 def list_economic_concepts(
     *,
     query: str | None = None,

--- a/src/ausecon_mcp/derived.py
+++ b/src/ausecon_mcp/derived.py
@@ -646,6 +646,7 @@ def derive_series(
             "truncated": truncated,
             "derived": {
                 "concept": spec.concept,
+                "description": spec.description,
                 "formula": spec.formula,
                 "operands": [
                     _operand_metadata(operand.name, operand.concept, operands[operand.name])

--- a/src/ausecon_mcp/schemas/response.schema.json
+++ b/src/ausecon_mcp/schemas/response.schema.json
@@ -372,6 +372,7 @@
       "type": "object",
       "required": [
         "concept",
+        "description",
         "formula",
         "operands",
         "source_concepts",
@@ -385,6 +386,9 @@
       "additionalProperties": false,
       "properties": {
         "concept": {
+          "type": "string"
+        },
+        "description": {
           "type": "string"
         },
         "formula": {

--- a/src/ausecon_mcp/server.py
+++ b/src/ausecon_mcp/server.py
@@ -16,13 +16,14 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ausecon_mcp.bounds import NormalisedSemanticBounds, normalise_semantic_bounds
 from ausecon_mcp.catalogue.resolver import (
-    list_economic_concepts as _list_economic_concepts,
-)
-from ausecon_mcp.catalogue.resolver import (
+    concepts_for_dataset,
     resolve,
     resolve_abs_dataflow_id,
     resolve_abs_structure_id,
     resolve_rba_csv_path,
+)
+from ausecon_mcp.catalogue.resolver import (
+    list_economic_concepts as _list_economic_concepts,
 )
 from ausecon_mcp.catalogue.search import list_catalogue as _list_catalogue
 from ausecon_mcp.catalogue.search import search_catalogue
@@ -409,6 +410,33 @@ def _reject_non_default_key(key: str, *, source: str) -> None:
         raise ValueError(f"key is only supported for source 'abs', not {source!r}.")
 
 
+# Below this many series there is no firehose worth flagging; a caller who passes
+# series_ids (or uses a curated concept) lands well under it and gets no nudge.
+NARROWING_HINT_MIN_SERIES = 10
+
+
+def _append_narrowing_guidance(payload: dict, source: str, identifier: str) -> None:
+    """Nudge callers off a heavy unfiltered curated dataset toward the lean path.
+
+    When a broad ``get_latest_observations`` / ``get_top_observations`` pull returns
+    many series from a dataset that has curated ``get_economic_series`` concept(s),
+    append a plain-English ``metadata.warnings`` line pointing at the concept and the
+    ``series_ids`` escape hatch. Appends (never assigns) so source warnings such as
+    APRA framework breaks are preserved.
+    """
+    concepts = concepts_for_dataset(source, identifier)
+    series = payload.get("series", [])
+    if not concepts or len(series) < NARROWING_HINT_MIN_SERIES:
+        return
+    head = ", ".join(concepts[:3])
+    message = (
+        f"{identifier} exposes {len(series)} series. For a single indicator call "
+        f"get_economic_series(concept='{concepts[0]}') (e.g. {head}), or pass "
+        f"series_ids=[...] to narrow this result."
+    )
+    payload.setdefault("metadata", {}).setdefault("warnings", []).append(message)
+
+
 class AuseconService:
     def __init__(
         self,
@@ -685,8 +713,7 @@ class AuseconService:
             )
         )
         operands = {
-            operand.name: payload
-            for operand, payload in zip(operand_specs, fetched, strict=True)
+            operand.name: payload for operand, payload in zip(operand_specs, fetched, strict=True)
         }
         return derive_series(
             validated_concept,
@@ -722,7 +749,9 @@ class AuseconService:
                 last_n=validated_count,
                 latest_n=validated_count,
             )
-            return select_latest_observations(payload, count=validated_count)
+            result = select_latest_observations(payload, count=validated_count)
+            _append_narrowing_guidance(result, validated_source, validated_identifier)
+            return result
 
         _reject_non_default_key(validated_key, source=validated_source)
         if validated_source == "rba":
@@ -732,7 +761,9 @@ class AuseconService:
                 series_ids=validate_series_ids(series_ids),
                 last_n=validated_count,
             )
-            return select_latest_observations(payload, count=validated_count)
+            result = select_latest_observations(payload, count=validated_count)
+            _append_narrowing_guidance(result, validated_source, validated_identifier)
+            return result
 
         validated_table_id = (
             None if table_id is None else validate_source_token("table_id", table_id)
@@ -743,7 +774,9 @@ class AuseconService:
             series_ids=validate_apra_series_ids(series_ids),
             last_n=validated_count,
         )
-        return select_latest_observations(payload, count=validated_count)
+        result = select_latest_observations(payload, count=validated_count)
+        _append_narrowing_guidance(result, validated_source, validated_identifier)
+        return result
 
     async def get_top_observations(
         self,
@@ -785,7 +818,9 @@ class AuseconService:
                 start_period=validated_start,
                 end_period=validated_end,
             )
-            return select_top_observations(payload, n=validated_n, direction=direction)
+            result = select_top_observations(payload, n=validated_n, direction=direction)
+            _append_narrowing_guidance(result, validated_source, validated_identifier)
+            return result
 
         _reject_non_default_key(validated_key, source=validated_source)
         _reject_parameter("start_period", start_period, source=validated_source)
@@ -804,7 +839,9 @@ class AuseconService:
                 start_date=validated_start_date,
                 end_date=validated_end_date,
             )
-            return select_top_observations(payload, n=validated_n, direction=direction)
+            result = select_top_observations(payload, n=validated_n, direction=direction)
+            _append_narrowing_guidance(result, validated_source, validated_identifier)
+            return result
 
         validated_table_id = (
             None if table_id is None else validate_source_token("table_id", table_id)
@@ -816,7 +853,9 @@ class AuseconService:
             start_date=validated_start_date,
             end_date=validated_end_date,
         )
-        return select_top_observations(payload, n=validated_n, direction=direction)
+        result = select_top_observations(payload, n=validated_n, direction=direction)
+        _append_narrowing_guidance(result, validated_source, validated_identifier)
+        return result
 
     async def describe_dataset(
         self,
@@ -1121,7 +1160,12 @@ def build_server(service: AuseconService | None = None) -> FastMCP:
         series_ids: OptionalSeriesIdList = None,
         count: LatestCount = 1,
     ) -> dict:
-        """Source-aware convenience wrapper for the latest observations."""
+        """Source-aware convenience wrapper for the latest observations.
+
+        For a single curated indicator prefer get_economic_series(concept=...), which
+        resolves one series; pass series_ids=[...] to narrow a broad dataset instead of
+        returning every series it contains.
+        """
         return await app_service.get_latest_observations(
             source=source,
             identifier=identifier,
@@ -1149,7 +1193,12 @@ def build_server(service: AuseconService | None = None) -> FastMCP:
         start_date: OptionalIsoDate = None,
         end_date: OptionalIsoDate = None,
     ) -> dict:
-        """Source-aware convenience wrapper for highest or lowest numeric observations."""
+        """Source-aware convenience wrapper for highest or lowest numeric observations.
+
+        For a single curated indicator prefer get_economic_series(concept=...), which
+        resolves one series; pass series_ids=[...] to narrow a broad dataset instead of
+        returning every series it contains.
+        """
         return await app_service.get_top_observations(
             source=source,
             identifier=identifier,

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -172,6 +172,7 @@ def test_real_cash_rate_carries_cash_rate_forward_to_monthly_cpi_periods() -> No
         ("2024-03", pytest.approx(0.6)),
     ]
     assert payload["metadata"]["derived"]["alignment_frequency"] == "Monthly"
+    assert "ex-post" in payload["metadata"]["derived"]["description"].lower()
 
 
 def test_real_wage_growth_subtracts_quarterly_cpi_year_ended_growth() -> None:
@@ -699,6 +700,10 @@ def test_terms_of_trade_metadata_carries_alignment_method() -> None:
     )
 
     assert payload["metadata"]["derived"]["alignment_method"] == "period_intersection"
+    assert (
+        payload["metadata"]["derived"]["description"]
+        == DERIVED_CONCEPTS["terms_of_trade"].description
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,6 +7,7 @@ from ausecon_mcp.catalogue.rba import RBA_CATALOGUE
 from ausecon_mcp.catalogue.resolver import (
     CURATED_SHORTCUTS,
     build_abs_key,
+    concepts_for_dataset,
     list_economic_concepts,
     resolve,
     resolve_abs_dataflow_id,
@@ -284,6 +285,17 @@ def test_resolve_rba_csv_path_uses_explicit_csv_path_when_declared() -> None:
         assert resolve_rba_csv_path("__test__") == "custom-file.csv"
     finally:
         del RBA_CATALOGUE["__test__"]
+
+
+def test_concepts_for_dataset_returns_curated_concepts_for_apra_dataset() -> None:
+    concepts = concepts_for_dataset("apra", "ADI_QUARTERLY_PERFORMANCE")
+    assert "adi_capital_ratio" in concepts
+    assert concepts == sorted(concepts)
+
+
+def test_concepts_for_dataset_returns_empty_for_unknown_dataset() -> None:
+    assert concepts_for_dataset("apra", "NOT_A_DATASET") == []
+    assert concepts_for_dataset("abs", "ADI_QUARTERLY_PERFORMANCE") == []
 
 
 def test_curated_shortcuts_cover_current_semantic_concepts() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -232,6 +232,37 @@ class StubAPRAProvider:
         }
 
 
+class HeavyAPRAProvider:
+    """APRA stub returning many series unfiltered, a single series when narrowed.
+
+    Carries a pre-existing source warning so tests can assert the narrowing
+    guidance is appended rather than overwriting framework-break warnings.
+    """
+
+    async def get_data(
+        self,
+        publication_id: str,
+        table_id: str | None = None,
+        series_ids: list[str] | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        last_n: int | None = None,
+    ) -> dict:
+        count = 1 if series_ids else 12
+        return {
+            "metadata": {
+                "source": "apra",
+                "dataset_id": publication_id,
+                "warnings": ["Framework break on 2023-01-01: definitions changed."],
+            },
+            "series": [{"series_id": f"s{i}"} for i in range(count)],
+            "observations": [
+                {"date": "2026-03-31", "series_id": f"s{i}", "value": float(i)}
+                for i in range(count)
+            ],
+        }
+
+
 class StubReleaseProvider:
     def __init__(self, events: list[dict]) -> None:
         self.events = events
@@ -721,6 +752,41 @@ async def test_service_get_latest_observations_rejects_apra_url_like_identifier(
             source="apra",
             identifier="https://www.apra.gov.au/sites/default/files/book.xlsx",
         )
+
+
+@pytest.mark.asyncio
+async def test_service_get_latest_observations_appends_narrowing_guidance() -> None:
+    service = AuseconService(apra_provider=HeavyAPRAProvider())
+
+    result = await service.get_latest_observations(
+        source="apra",
+        identifier="ADI_QUARTERLY_PERFORMANCE",
+        count=1,
+    )
+
+    warnings = result["metadata"]["warnings"]
+    # Pre-existing source warning preserved (appended, not overwritten).
+    assert "Framework break on 2023-01-01: definitions changed." in warnings
+    nudges = [w for w in warnings if "get_economic_series" in w]
+    assert len(nudges) == 1
+    assert "adi_capital_ratio" in nudges[0]
+    assert "series_ids" in nudges[0]
+
+
+@pytest.mark.asyncio
+async def test_service_get_latest_observations_suppresses_guidance_when_narrowed() -> None:
+    service = AuseconService(apra_provider=HeavyAPRAProvider())
+
+    result = await service.get_latest_observations(
+        source="apra",
+        identifier="ADI_QUARTERLY_PERFORMANCE",
+        series_ids=["ADI_QUARTERLY_PERFORMANCE:key_stats:key_figures:total_capital_ratio"],
+        count=1,
+    )
+
+    warnings = result["metadata"].get("warnings", [])
+    assert not any("get_economic_series" in w for w in warnings)
+    assert len(result["series"]) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Derived series now expose their concept description in metadata.derived.description (required in the response schema), so the ex-post real-rate caveats reach MCP clients instead of living only in source. The schema change is additive; tool signatures are unchanged.

get_latest_observations and get_top_observations append a metadata.warnings nudge toward get_economic_series(concept=...) and the series_ids filter when an unfiltered curated dataset returns many series (e.g. all of ADI_QUARTERLY_PERFORMANCE). The nudge is suppressed once a result is narrowed and is appended without clobbering existing source warnings such as APRA framework breaks.