### PR TITLE
fix(docs-deps): bump vite to 7.3.5 (clears 2 Dependabot alerts)

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -6714,9 +6714,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -23,6 +23,7 @@
     "yaml-language-server": {
       "yaml": "^2.8.3"
     },
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "vite": "^7.3.5"
   }
 }


### PR DESCRIPTION
## Summary
- Pins `vite` to `^7.3.5` via the docs-site `overrides` block, clearing both open Dependabot alerts.
- `vite` is a **transitive** dependency (via `astro@6.4.6`, resolved to `7.3.2`), so Dependabot could not open a PR automatically — there is no top-level `vite` entry to bump. This uses the same `overrides` pattern the repo already uses for `esbuild`.

Resolves:
- **GHSA-fx2h-pf6j-xcff** (high) — `server.fs.deny` bypass on Windows alternate paths
- **GHSA-v6wh-96g9-6wx3** (moderate) — launch-editor NTLMv2 hash disclosure via UNC path handling on Windows

## Test Plan
- [x] `npm install` resolves `vite@7.3.5` across the tree (`astro` and `vitefu` deduped)
- [x] `npm audit` reports **0 vulnerabilities**
- [x] `npm run build` succeeds (18 pages)